### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Requirements for RedHat-based distributions:
 
 As root you can run
 
-	dnf install gcc-g++ make cmake qt5-devel libXtst-devel libjpeg-turbo-devel zlib-devel  \
+	dnf install gcc-c++ make cmake qt5-devel libXtst-devel libjpeg-turbo-devel zlib-devel  \
              openssl-devel pam-devel lzo-devel qca-devel qca-qt5-devel openldap-devel libgsasl
 
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ If some requirements are not fullfilled, CMake will inform you about it and
 you will have to install the missing software before continuing.
 
 You can now generate a package (.deb or .rpm depending what system you are in).
+
+On Fedora, this requires an additional dependency (rpm-build) which can be installed by running
+
+	dnf install rpm-build
+
 For generating a package you can run
     
 	make package


### PR DESCRIPTION
On Fedora 26 (at least), this command doesn't run (it complains it can't find gcc-g++).  The new package name is gcc-c++.  