### PR TITLE
More README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Run the following commands:
 	cmake ..
 	make -j4
 
+NOTE: If you want to build a .deb or .rpm package for this software, instead of the provided cmake command, you should use:
+
+	cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+
+to install package files in /usr instead of /usr/local.
+
 If some requirements are not fullfilled, CMake will inform you about it and
 you will have to install the missing software before continuing.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Requirements for RedHat-based distributions:
 
 As root you can run
 
-	dnf install gcc-g++ make cmake qt5-devel libXtst-devel libjpeg-turbo-devel zlib-devel  \
+	dnf install gcc-c++ make cmake qt5-devel libXtst-devel libjpeg-turbo-devel zlib-devel  \
              openssl-devel pam-devel lzo-devel qca-devel qca-qt5-devel openldap-devel libgsasl
 
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ If some requirements are not fullfilled, CMake will inform you about it and
 you will have to install the missing software before continuing.
 
 You can now generate a package (.deb or .rpm depending what system you are in).
+
+On Fedora, this requires an additional dependency (rpm-build) which can be installed by running
+
+	dnf install rpm-build
+
 For generating a package you can run
     
 	make package


### PR DESCRIPTION
If you try to install after using "make package" in Fedora, you will encounter an error like the following:

file /usr/local from install of veyon-3.99.7-1.x86_64 conflicts with file from package filesystem-3.2-40.fc26.x86_64
file /usr/local/bin from install of veyon-3.99.7-1.x86_64 conflicts with file from package filesystem-3.2-40.fc26.x86_64
file /usr/local/lib64 from install of veyon-3.99.7-1.x86_64 conflicts with file from package filesystem-3.2-40.fc26.x86_64

The reason for this is that CMake defaults to installation in /usr/local and /usr/local is reserved for manually installed packages.  Packages installed through the package manager (rpm) are supposed to go in /usr.  This is easy to fix by providing a -DCMAKE_INSTALL_PREFIX flag, but it should be documented in the README.
