### PR TITLE
Change submodules' URL to full path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "3rdparty/ultravnc"]
 	path = 3rdparty/ultravnc
-	url = ../ultravnc.git
+	url = git://github.com/veyon/ultravnc.git
 [submodule "3rdparty/kldap"]
 	path = 3rdparty/kldap
 	url = git://anongit.kde.org/kldap.git
 [submodule "3rdparty/libvncserver"]
 	path = 3rdparty/libvncserver
-	url = ../libvncserver.git
+	url = git://github.com/veyon/libvncserver.git
 [submodule "3rdparty/x11vnc"]
 	path = 3rdparty/x11vnc
-	url = ../x11vnc.git
+	url = git://github.com/veyon/x11vnc.git


### PR DESCRIPTION
Change submodules' URL to full path

Relative path works when it's cloned the original veyon repository,
but if we fork that repository, `git submodule update --init` command
doesn't work properly.

;)