### PR TITLE
"free(): double free detected in tcache 2" has been resolved

### DIFF
--- a/plugins/platform/linux/auth-helper/VeyonAuthHelper.cpp
+++ b/plugins/platform/linux/auth-helper/VeyonAuthHelper.cpp
@@ -105,9 +105,5 @@ int main()
 
 	pam_end( pamh, err );
 
-	delete[] pam_username;
-	delete[] pam_password;
-	delete[] pam_service;
-
 	return err == PAM_SUCCESS ? 0 : -1;
 }


### PR DESCRIPTION
Windows AD authentication is working again through sssd

pam_end( pamh, err )

This function free's all memory for items associated with the pam_set_item(3) and pam_get_item(3) functions. Pointers associated with such objects are not valid anymore after pam_end was called.