### PR TITLE
Allow remote log in when a logon message is displayed.

### DIFF
--- a/plugins/platform/windows/WindowsPlatformConfiguration.h
+++ b/plugins/platform/windows/WindowsPlatformConfiguration.h
@@ -34,5 +34,6 @@
 	OP( WindowsPlatformConfiguration, m_configuration, bool, hideStartMenuForScreenLock, setHideStartMenuForScreenLock, "HideStartMenuForScreenLock", "Windows", true, Configuration::Property::Flag::Advanced ) \
 	OP( WindowsPlatformConfiguration, m_configuration, int, logonInputStartDelay, setLogonInputStartDelay, "LogonInputStartDelay", "Windows", 1000, Configuration::Property::Flag::Advanced ) \
 	OP( WindowsPlatformConfiguration, m_configuration, int, logonKeyPressInterval, setLogonKeyPressInterval, "LogonKeyPressInterval", "Windows", 10, Configuration::Property::Flag::Advanced ) \
+	OP( WindowsPlatformConfiguration, m_configuration, bool, logonMessageUsed, setLogonMessageUsed, "LogonMessageUsed", "Windows", false, Configuration::Property::Flag::Advanced ) \
 
 DECLARE_CONFIG_PROXY(WindowsPlatformConfiguration, FOREACH_WINDOWS_PLATFORM_CONFIG_PROPERTY)

--- a/plugins/platform/windows/WindowsPlatformConfigurationPage.ui
+++ b/plugins/platform/windows/WindowsPlatformConfigurationPage.ui
@@ -101,6 +101,15 @@
        </widget>
       </item>
      </layout>
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <item>
+       <widget class="QCheckBox" name="logonMessageUsed">
+        <property name="text">
+         <string>Message is displayed before user logs in</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
@@ -153,6 +162,7 @@
   <tabstop>disableSSPIBasedUserAuthentication</tabstop>
   <tabstop>logonInputStartDelay</tabstop>
   <tabstop>logonKeyPressInterval</tabstop>
+  <tabstop>logonMessageUsed</tabstop>
   <tabstop>hideTaskbarForScreenLock</tabstop>
   <tabstop>hideStartMenuForScreenLock</tabstop>
   <tabstop>hideDesktopForScreenLock</tabstop>

--- a/plugins/platform/windows/WindowsPlatformConfigurationPage.ui
+++ b/plugins/platform/windows/WindowsPlatformConfigurationPage.ui
@@ -100,9 +100,7 @@
         </property>
        </widget>
       </item>
-     </layout>
-     <layout class="QVBoxLayout" name="verticalLayout_5">
-      <item>
+      <item row="2">
        <widget class="QCheckBox" name="logonMessageUsed">
         <property name="text">
          <string>Message is displayed before user logs in</string>

--- a/plugins/platform/windows/WindowsUserFunctions.cpp
+++ b/plugins/platform/windows/WindowsUserFunctions.cpp
@@ -198,7 +198,7 @@ bool WindowsUserFunctions::performLogon( const QString& username, const Password
 
 	input.pressAndReleaseKey( XK_Delete );
 	
-	if (config.logonMessageUsed) {
+	if (config.logonMessageUsed()) {
 		input.pressAndReleaseKey( XK_Return );
 		QThread::msleep( static_cast<unsigned long>( config.logonInputStartDelay() ) );
 	}

--- a/plugins/platform/windows/WindowsUserFunctions.cpp
+++ b/plugins/platform/windows/WindowsUserFunctions.cpp
@@ -197,6 +197,11 @@ bool WindowsUserFunctions::performLogon( const QString& username, const Password
 	QThread::msleep( static_cast<unsigned long>( config.logonInputStartDelay() ) );
 
 	input.pressAndReleaseKey( XK_Delete );
+	
+	if (config.logonMessageUsed) {
+		input.pressAndReleaseKey( XK_Return );
+		QThread::msleep( static_cast<unsigned long>( config.logonInputStartDelay() ) );
+	}
 
 	sendString( username );
 


### PR DESCRIPTION
Lots of environments have a message displayed before people log in. This message currently prevents the remote log in feature from working correctly.
Currently the only workaround is to disable the login message, as per #569.

This is not suitable for environments where students may be able to log in themselves at time while at other times the computers are logged in for them.

This pull request adds a configuration option to set that a log on message is used, which will proceed through the login message and log in as the desired user.