### PR TITLE
add username to remoteaccess window title and update on userChanged s…

### DIFF
--- a/plugins/remoteaccess/RemoteAccessWidget.cpp
+++ b/plugins/remoteaccess/RemoteAccessWidget.cpp
@@ -384,7 +384,7 @@ void RemoteAccessWidget::updateRemoteAccessTitle()
 														   VeyonCore::applicationName() ) );
 	} else
 	{
-		setWindowTitle( tr( "%1 - %2 - %3 - Remote Access" ).arg( m_computerControlInterface->userFullName(),
+		setWindowTitle( tr( "%1 - %2 - %3 Remote Access" ).arg( m_computerControlInterface->userFullName(),
 																  m_computerControlInterface->computer().name(),
 																  VeyonCore::applicationName() ) );
 	}

--- a/plugins/remoteaccess/RemoteAccessWidget.cpp
+++ b/plugins/remoteaccess/RemoteAccessWidget.cpp
@@ -252,8 +252,9 @@ RemoteAccessWidget::RemoteAccessWidget( const ComputerControlInterface::Pointer&
 	m_vncView( new VncViewWidget( computerControlInterface->computer().hostAddress(), -1, this, VncView::RemoteControlMode ) ),
 	m_toolBar( new RemoteAccessWidgetToolBar( this, startViewOnly, showViewOnlyToggleButton ) )
 {
-	setWindowTitle( tr( "%1 - %2 Remote Access" ).arg( computerControlInterface->computer().name(),
-													   VeyonCore::applicationName() ) );
+	updateRemoteAccessTitle();
+	connect( m_computerControlInterface.data(), &ComputerControlInterface::userChanged, this, &RemoteAccessWidget::updateRemoteAccessTitle );
+
 	setWindowIcon( QPixmap( QStringLiteral(":/remoteaccess/kmag.png") ) );
 	setAttribute( Qt::WA_DeleteOnClose, true );
 
@@ -371,4 +372,20 @@ void RemoteAccessWidget::toggleViewOnly( bool viewOnly )
 void RemoteAccessWidget::takeScreenshot()
 {
 	Screenshot().take( m_computerControlInterface );
+}
+
+
+
+void RemoteAccessWidget::updateRemoteAccessTitle()
+{
+	if ( m_computerControlInterface->userFullName().isEmpty() )
+	{
+		setWindowTitle( tr( "%1 - %2 Remote Access" ).arg( m_computerControlInterface->computer().name(),
+														   VeyonCore::applicationName() ) );
+	} else
+	{
+		setWindowTitle( tr( "%1 - %2 - %3 - Remote Access" ).arg( m_computerControlInterface->userFullName(),
+																  m_computerControlInterface->computer().name(),
+																  VeyonCore::applicationName() ) );
+	}
 }

--- a/plugins/remoteaccess/RemoteAccessWidget.h
+++ b/plugins/remoteaccess/RemoteAccessWidget.h
@@ -96,7 +96,6 @@ public:
 	void toggleViewOnly( bool viewOnly );
 	void takeScreenshot();
 
-
 protected:
 	bool eventFilter( QObject* object, QEvent* event ) override;
 	void enterEvent( QEvent* event ) override;
@@ -105,6 +104,7 @@ protected:
 
 private:
 	void updateSize();
+	void updateRemoteAccessTitle();
 
 	ComputerControlInterface::Pointer m_computerControlInterface;
 	VncViewWidget* m_vncView;


### PR DESCRIPTION
…ignal

This hopefully addresses the problems you pointed out with my first PR trying to add the username to the RemoteAccessWindow.

Now if the username changes while the window is open, it updates it. If no user is known or not yet known, it falls back to the old way of displaying only the pc name.