### PR TITLE
add possibility to hide features from menu or context menu

### DIFF
--- a/core/src/Feature.h
+++ b/core/src/Feature.h
@@ -50,6 +50,8 @@ public:
 		Service = 0x0200,
 		Worker = 0x0400,
 		Builtin = 0x1000,
+		NoContext = 0x2000,
+		NoMenu = 0x4000,
 		AllComponents = Master | Service | Worker
 	} ;
 

--- a/master/src/ComputerMonitoringWidget.cpp
+++ b/master/src/ComputerMonitoringWidget.cpp
@@ -197,7 +197,7 @@ void ComputerMonitoringWidget::populateFeatureMenu(  const ComputerControlInterf
 
 	for( const auto& feature : master()->features() )
 	{
-		if( feature.testFlag( Feature::Internal ) )
+		if( feature.testFlag( Feature::Internal ) || feature.testFlag( Feature::NoContext ) )
 		{
 			continue;
 		}

--- a/master/src/MainWindow.cpp
+++ b/master/src/MainWindow.cpp
@@ -411,7 +411,7 @@ void MainWindow::addFeaturesToToolBar()
 {
 	for( const auto& feature : m_master.features() )
 	{
-		if( feature.testFlag( Feature::Internal ) )
+		if( feature.testFlag( Feature::Internal ) || feature.testFlag( Feature::NoMenu ) )
 		{
 			continue;
 		}


### PR DESCRIPTION
As we both know now, where we want to go with this, I think it will be easier to review and discuss the new code if it is not one lage pull request but some smaller ones. I hope this is okay with you.

In preparation for the discussed ComputerZoomWidget I propose to add the possibility to hide features from the menu bar or context menu. I did/could not use Feature::Internal as this would hide the feature from the future left press and hold veyon-configurator option, too.

