### PR TITLE
auto select last item on add and remove

### DIFF
--- a/master/src/SpotlightPanel.cpp
+++ b/master/src/SpotlightPanel.cpp
@@ -137,9 +137,16 @@ void SpotlightPanel::remove()
 	auto selection = ui->monitoringWidget->selectionModel()->selectedIndexes();
 	if( selection.isEmpty() )
 	{
-		QMessageBox::information( this, tr("Spotlight"),
-								  tr( "Please select at least one computer to remove.") );
-		return;
+		if( m_model->rowCount() > 0 )
+		{
+			const auto lastIndex = m_model->index(m_model->rowCount() - 1, 0);
+			ui->monitoringWidget->selectionModel()->select(lastIndex, QItemSelectionModel::Select);
+			selection = ui->monitoringWidget->selectionModel()->selectedIndexes();
+		} else {
+			QMessageBox::information( this, tr("Spotlight"),
+									  tr( "Please select at least one computer to remove.") );
+			return;
+		}
 	}
 
 	while( selection.isEmpty() == false )

--- a/master/src/SpotlightPanel.ui
+++ b/master/src/SpotlightPanel.ui
@@ -85,7 +85,8 @@
           </font>
          </property>
          <property name="text">
-          <string>Add computers by clicking with the middle mouse button or clicking the first button below.</string>
+          <string>Add computers by clicking with the middle mouse button or clicking the first button below.
+The second button will remove the selected computer. If nothing is selected the last one will be removed.</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>


### PR DESCRIPTION
This will auto select the last item when something is added by middle mouse clicking or selecting and using the add or remove button.

It does not yet work correctly if the last item in the spotlight panel is middle mouse clicked. The selection is set, but removed again by something else, which I was not able to find yet. If another than the last item is clicked, it works fine.

**Also I noticed a crash of the master application** probably not related to this code or the previous change to the Spotlight Panel. (I reverted both changes to test and the crash still happens.) If more than one item is selected and the removal is triggered, the master crashes with a memory access violation error. At least this happens on my system, maybe you could test, too?