### PR TITLE
BuiltinDirectory: disable addComputerButton if no location exists

### DIFF
--- a/plugins/builtindirectory/BuiltinDirectoryConfigurationPage.cpp
+++ b/plugins/builtindirectory/BuiltinDirectoryConfigurationPage.cpp
@@ -208,7 +208,9 @@ void BuiltinDirectoryConfigurationPage::populateLocations()
 	ui->locationTableWidget->setUpdatesEnabled( true );
 
 	if( rowCount > 0 )
+	{
 		ui->addComputerButton->setEnabled( true );
+	}
 }
 
 

--- a/plugins/builtindirectory/BuiltinDirectoryConfigurationPage.cpp
+++ b/plugins/builtindirectory/BuiltinDirectoryConfigurationPage.cpp
@@ -177,6 +177,8 @@ void BuiltinDirectoryConfigurationPage::populateLocations()
 	ui->locationTableWidget->setUpdatesEnabled( false );
 	ui->locationTableWidget->clear();
 
+	ui->addComputerButton->setEnabled( false );
+
 	int rowCount = 0;
 
 	const auto networkObjects = m_configuration.networkObjects();
@@ -193,6 +195,9 @@ void BuiltinDirectoryConfigurationPage::populateLocations()
 	}
 
 	ui->locationTableWidget->setUpdatesEnabled( true );
+
+	if( rowCount > 0 )
+		ui->addComputerButton->setEnabled( true );
 }
 
 

--- a/plugins/builtindirectory/BuiltinDirectoryConfigurationPage.cpp
+++ b/plugins/builtindirectory/BuiltinDirectoryConfigurationPage.cpp
@@ -111,11 +111,22 @@ void BuiltinDirectoryConfigurationPage::updateLocation()
 
 void BuiltinDirectoryConfigurationPage::removeLocation()
 {
+	auto currentRow = ui->locationTableWidget->currentRow();
+
 	ObjectManager<NetworkObject> objectManager( m_configuration.networkObjects() );
 	objectManager.remove( currentLocationObject().uid(), true );
 	m_configuration.setNetworkObjects( objectManager.objects() );
 
 	populateLocations();
+
+	if( currentRow > 0 )
+	{
+		ui->locationTableWidget->setCurrentCell( currentRow-1, 0 );
+	}
+	else if ( ui->locationTableWidget->rowCount() > 0 )
+	{
+		ui->locationTableWidget->setCurrentCell( currentRow, 0 );
+	}
 }
 
 


### PR DESCRIPTION
Hi,

I found that Computer objects created outside of the location got lost and didn't display in veyon-master Locations/Computers list, so I guess users are not supposed to create them.