### PR TITLE
LinuxUserFunctions: fix login key sequence selection

### DIFF
--- a/plugins/platform/linux/LinuxUserFunctions.cpp
+++ b/plugins/platform/linux/LinuxUserFunctions.cpp
@@ -301,7 +301,7 @@ bool LinuxUserFunctions::performLogon( const QString& username, const Password& 
 
 	auto sequence = LinuxPlatformConfiguration( &VeyonCore::config() ).userLoginKeySequence();
 
-	if( sequence.isEmpty() == false )
+	if( sequence.isEmpty() == true )
 	{
 		sequence = QStringLiteral("%username%<Tab>%password%<Return>");
 	}


### PR DESCRIPTION
Use default key sequence when configuration is empty