### PR TITLE
Core: remove unused variable 'index'

### DIFF
--- a/core/src/NetworkObjectDirectory.cpp
+++ b/core/src/NetworkObjectDirectory.cpp
@@ -83,14 +83,12 @@ const NetworkObject& NetworkObjectDirectory::object( NetworkObject::ModelId pare
 	const auto it = m_objects.constFind( parent );
 	if( it != m_objects.end() )
 	{
-		int index = 0;
 		for( const auto& entry : *it )
 		{
 			if( entry.modelId() == object )
 			{
 				return entry;
 			}
-			++index;
 		}
 	}
 


### PR DESCRIPTION
First of all, thank you for your great service veyon!
I think variable 'index' in core/src/NetworkObjectDirectory.cpp is not being used, so I suggest to remove it. Am I thinking right?
