### PR TITLE
fix press and hold and maximized state of remote views on windows

### DIFF
--- a/master/src/ComputerMonitoringWidget.cpp
+++ b/master/src/ComputerMonitoringWidget.cpp
@@ -285,6 +285,7 @@ void ComputerMonitoringWidget::runDoubleClickFeature( const QModelIndex& index )
 
 void ComputerMonitoringWidget::runMousePressAndHoldFeature( )
 {
+	m_mousePressAndHold.stop();
 	const auto selectedInterfaces = selectedComputerControlInterfaces();
 	if( !m_ignoreMousePressAndHoldEvent &&
 		selectedInterfaces.count() > 0 &&
@@ -293,9 +294,9 @@ void ComputerMonitoringWidget::runMousePressAndHoldFeature( )
 		selectedInterfaces.first()->hasValidFramebuffer() )
    {
 		m_ignoreMousePressAndHoldEvent = true;
+		m_ignoreNumberOfMouseEvents = IgnoredNumberOfMouseEventsWhileHold;
 		delete m_computerZoomWidget;
 		m_computerZoomWidget = new ComputerZoomWidget( selectedInterfaces.first()  );
-		QApplication::setOverrideCursor(Qt::BlankCursor);
    }
 }
 
@@ -303,9 +304,11 @@ void ComputerMonitoringWidget::runMousePressAndHoldFeature( )
 
 void ComputerMonitoringWidget::stopMousePressAndHoldFeature( )
 {
+	m_ignoreMousePressAndHoldEvent = false;
+	m_ignoreNumberOfMouseEvents = 0;
+	m_computerZoomWidget->close();
 	delete m_computerZoomWidget;
 	m_computerZoomWidget = nullptr;
-	QApplication::restoreOverrideCursor();
 }
 
 
@@ -333,7 +336,6 @@ void ComputerMonitoringWidget::mouseReleaseEvent( QMouseEvent* event )
 	{
 		stopMousePressAndHoldFeature();
 	}
-	m_ignoreMousePressAndHoldEvent = false;
 	QListView::mouseReleaseEvent( event );
 }
 
@@ -342,12 +344,19 @@ void ComputerMonitoringWidget::mouseReleaseEvent( QMouseEvent* event )
 void ComputerMonitoringWidget::mouseMoveEvent( QMouseEvent* event )
 {
 	m_mousePressAndHold.stop();
-	if ( m_ignoreMousePressAndHoldEvent )
+	if ( m_ignoreNumberOfMouseEvents <= 0 )
 	{
-		stopMousePressAndHoldFeature();
+		if ( m_ignoreMousePressAndHoldEvent )
+		{
+			stopMousePressAndHoldFeature();
+		}
+
+		QListView::mouseMoveEvent( event );
+	} else
+	{
+		m_ignoreNumberOfMouseEvents--;
+		event->accept();
 	}
-	m_ignoreMousePressAndHoldEvent = false;
-	QListView::mouseMoveEvent( event );
 }
 
 

--- a/master/src/ComputerMonitoringWidget.h
+++ b/master/src/ComputerMonitoringWidget.h
@@ -73,7 +73,8 @@ private:
 
 	void mousePressEvent( QMouseEvent* event ) override;
 	void mouseReleaseEvent( QMouseEvent* event ) override;
-	void mouseMoveEvent( QMouseEvent * event ) override;
+	void mouseMoveEvent( QMouseEvent* event ) override;
+
 	void resizeEvent( QResizeEvent* event ) override;
 	void showEvent( QShowEvent* event ) override;
 	void wheelEvent( QWheelEvent* event ) override;
@@ -82,6 +83,9 @@ private:
 	bool m_ignoreMousePressAndHoldEvent{false};
 	bool m_ignoreWheelEvent{false};
 	bool m_ignoreResizeEvent{false};
+	int m_ignoreNumberOfMouseEvents = 0;
+
+	static constexpr auto IgnoredNumberOfMouseEventsWhileHold = 3;
 
 	ComputerZoomWidget* m_computerZoomWidget{nullptr};
 

--- a/master/src/ComputerZoomWidget.h
+++ b/master/src/ComputerZoomWidget.h
@@ -38,8 +38,14 @@ public:
 	ComputerZoomWidget( const ComputerControlInterface::Pointer& computerControlInterface );
 	~ComputerZoomWidget() override;
 
+protected:
+	void resizeEvent( QResizeEvent* event ) override;
+
 private:
+	void updateSize();
 	void updateComputerZoomWidgetTitle();
+
+	void closeEvent( QCloseEvent* event ) override;
 
 	VncViewWidget* m_vncView;
 


### PR DESCRIPTION
This PR should fix the issue #775 where the press and hold feature is closing its remote view window automatically on windows systems. Also it fixes the maximized state of the remote view windows, which was not working correctly on windows systems, too.