### PR TITLE
allow screenswitching in RemoteAccessWidget *Please review, but don't merge yet!*

### DIFF
--- a/master/src/ComputerMonitoringWidget.cpp
+++ b/master/src/ComputerMonitoringWidget.cpp
@@ -285,6 +285,7 @@ void ComputerMonitoringWidget::runDoubleClickFeature( const QModelIndex& index )
 
 void ComputerMonitoringWidget::runMousePressAndHoldFeature( )
 {
+	m_mousePressAndHold.stop();
 	const auto selectedInterfaces = selectedComputerControlInterfaces();
 	if( !m_ignoreMousePressAndHoldEvent &&
 		selectedInterfaces.count() > 0 &&

--- a/master/src/ComputerMonitoringWidget.cpp
+++ b/master/src/ComputerMonitoringWidget.cpp
@@ -293,9 +293,9 @@ void ComputerMonitoringWidget::runMousePressAndHoldFeature( )
 		selectedInterfaces.first()->hasValidFramebuffer() )
    {
 		m_ignoreMousePressAndHoldEvent = true;
+		m_ignoreNumberOfMouseEvents = 3;
 		delete m_computerZoomWidget;
 		m_computerZoomWidget = new ComputerZoomWidget( selectedInterfaces.first()  );
-		QApplication::setOverrideCursor(Qt::BlankCursor);
    }
 }
 
@@ -303,9 +303,11 @@ void ComputerMonitoringWidget::runMousePressAndHoldFeature( )
 
 void ComputerMonitoringWidget::stopMousePressAndHoldFeature( )
 {
+	m_ignoreMousePressAndHoldEvent = false;
+	m_ignoreNumberOfMouseEvents = 0;
+	m_computerZoomWidget->close();
 	delete m_computerZoomWidget;
 	m_computerZoomWidget = nullptr;
-	QApplication::restoreOverrideCursor();
 }
 
 
@@ -333,7 +335,6 @@ void ComputerMonitoringWidget::mouseReleaseEvent( QMouseEvent* event )
 	{
 		stopMousePressAndHoldFeature();
 	}
-	m_ignoreMousePressAndHoldEvent = false;
 	QListView::mouseReleaseEvent( event );
 }
 
@@ -342,12 +343,19 @@ void ComputerMonitoringWidget::mouseReleaseEvent( QMouseEvent* event )
 void ComputerMonitoringWidget::mouseMoveEvent( QMouseEvent* event )
 {
 	m_mousePressAndHold.stop();
-	if ( m_ignoreMousePressAndHoldEvent )
+	if ( m_ignoreNumberOfMouseEvents <= 0 )
 	{
-		stopMousePressAndHoldFeature();
+		if ( m_ignoreMousePressAndHoldEvent )
+		{
+			stopMousePressAndHoldFeature();
+		}
+
+		QListView::mouseMoveEvent( event );
+	} else
+	{
+		m_ignoreNumberOfMouseEvents--;
+		event->accept();
 	}
-	m_ignoreMousePressAndHoldEvent = false;
-	QListView::mouseMoveEvent( event );
 }
 
 

--- a/master/src/ComputerMonitoringWidget.h
+++ b/master/src/ComputerMonitoringWidget.h
@@ -73,7 +73,8 @@ private:
 
 	void mousePressEvent( QMouseEvent* event ) override;
 	void mouseReleaseEvent( QMouseEvent* event ) override;
-	void mouseMoveEvent( QMouseEvent * event ) override;
+	void mouseMoveEvent( QMouseEvent* event ) override;
+
 	void resizeEvent( QResizeEvent* event ) override;
 	void showEvent( QShowEvent* event ) override;
 	void wheelEvent( QWheelEvent* event ) override;
@@ -82,6 +83,7 @@ private:
 	bool m_ignoreMousePressAndHoldEvent{false};
 	bool m_ignoreWheelEvent{false};
 	bool m_ignoreResizeEvent{false};
+	int m_ignoreNumberOfMouseEvents;
 
 	ComputerZoomWidget* m_computerZoomWidget{nullptr};
 

--- a/master/src/ComputerZoomWidget.h
+++ b/master/src/ComputerZoomWidget.h
@@ -38,15 +38,26 @@ public:
 	ComputerZoomWidget( const ComputerControlInterface::Pointer& computerControlInterface );
 	~ComputerZoomWidget() override;
 
+	VncViewWidget* vncView() const
+	{
+		return m_vncView;
+	}
+
 protected:
+	bool eventFilter( QObject* object, QEvent* event ) override;
+
 	void resizeEvent( QResizeEvent* event ) override;
+	void closeEvent( QCloseEvent* event ) override;
 
 private:
 	void updateSize();
 	void updateComputerZoomWidgetTitle();
 
-	void closeEvent( QCloseEvent* event ) override;
+	int currentScreen;
 
 	VncViewWidget* m_vncView;
+
+Q_SIGNALS:
+	void keypressInComputerZoomWidget( );
 
 } ;

--- a/master/src/ComputerZoomWidget.h
+++ b/master/src/ComputerZoomWidget.h
@@ -38,8 +38,14 @@ public:
 	ComputerZoomWidget( const ComputerControlInterface::Pointer& computerControlInterface );
 	~ComputerZoomWidget() override;
 
+protected:
+	void resizeEvent( QResizeEvent* event ) override;
+
 private:
+	void updateSize();
 	void updateComputerZoomWidgetTitle();
+
+	void closeEvent( QCloseEvent* event ) override;
 
 	VncViewWidget* m_vncView;
 

--- a/plugins/remoteaccess/RemoteAccessWidget.cpp
+++ b/plugins/remoteaccess/RemoteAccessWidget.cpp
@@ -321,10 +321,10 @@ RemoteAccessWidget::RemoteAccessWidget( const ComputerControlInterface::Pointer&
 	connect( m_vncView, &VncViewWidget::mouseAtBorder, m_toolBar, &RemoteAccessWidgetToolBar::appear );
 	connect( m_vncView, &VncViewWidget::sizeHintChanged, this, &RemoteAccessWidget::updateSize );
 
-	showMaximized();
+	setWindowState(Qt::WindowMaximized);
 	VeyonCore::platform().coreFunctions().raiseWindow( this, false );
 
-	showNormal();
+	show();
 
 	setViewOnly( startViewOnly );
 }

--- a/plugins/remoteaccess/RemoteAccessWidget.h
+++ b/plugins/remoteaccess/RemoteAccessWidget.h
@@ -47,6 +47,7 @@ public:
 	void appear();
 	void disappear();
 	void updateControls( bool viewOnly );
+	void updateScreenSelectActions( int newScreen );
 
 
 protected:
@@ -116,5 +117,10 @@ private:
 	RemoteAccessWidgetToolBar* m_toolBar;
 
 	static constexpr int AppearDelay = 500;
+
+	int currentScreen;
+
+Q_SIGNALS:
+	void screenChangedInRemoteAccessWidget( int newScreen );
 
 } ;


### PR DESCRIPTION
This is a proof of concept and will allow to switch screens by pressing tab or backtab while in the viewOnly Mode of the RemoteAccessWidget.

It is based on my previous PR #783 so those commits are included. The new code of this PR is in the last commit.

It still has a lot of debugging output inside, which will need to be removed for the code to be mergeable.

Please review and let me know, if it is an acceptable idea.