### PR TITLE
fix remote view and control window maximizing

### DIFF
--- a/plugins/remoteaccess/RemoteAccessWidget.cpp
+++ b/plugins/remoteaccess/RemoteAccessWidget.cpp
@@ -321,10 +321,10 @@ RemoteAccessWidget::RemoteAccessWidget( const ComputerControlInterface::Pointer&
 	connect( m_vncView, &VncViewWidget::mouseAtBorder, m_toolBar, &RemoteAccessWidgetToolBar::appear );
 	connect( m_vncView, &VncViewWidget::sizeHintChanged, this, &RemoteAccessWidget::updateSize );
 
-	showMaximized();
+	setWindowState(Qt::WindowMaximized);
 	VeyonCore::platform().coreFunctions().raiseWindow( this, false );
 
-	showNormal();
+	show();
 
 	setViewOnly( startViewOnly );
 }


### PR DESCRIPTION
This harmonizes the behavior between the ComputerZoomWidgets preview window and the remote view and control plugin window(s).

Maximizing the window ensures the correct OS independent positioning of the window on the desired screen (main or masters).

Without this, the window on Windows OS would not positioned correctly on the desired screen and partly show outside the viewable space or "bleed" into the main screen. This happens especially if the teachers resolution is smaller, than those of the students screens. If the main screen is mirrored on a projector for the students to see, they will notice each time the teacher reviews in full size, what they are doing. The teacher will have to manually maximize or move the window each time a remote view or control is opened, to move the window out of the view of the students.

Also when switching between student screens in an multi monitor environment the maximized window returns to an scaled view when switching to "all screen" mode from displaying a single student screen.

Without this, instead of scaling again, the window would enlarge to fit the full size students screens and partly show outside the viewable space or "bleed" into the other screen. As before, this happens especially often, if the resolutions don't match. The teacher would then have to manually maximize or resize the window or close and reopen to get back to the scaled view. This has to be repeated each time a remote view or control window is opened.