### PR TITLE
ComputerZoomWidget: allow screen switching by pressing tab or backtab

### DIFF
--- a/master/src/ComputerMonitoringWidget.cpp
+++ b/master/src/ComputerMonitoringWidget.cpp
@@ -283,6 +283,13 @@ void ComputerMonitoringWidget::runDoubleClickFeature( const QModelIndex& index )
 
 
 
+void ComputerMonitoringWidget::resetIgnoreNumberOfMouseEvents( )
+{
+	m_ignoreNumberOfMouseEvents = IgnoredNumberOfMouseEventsWhileHold;
+}
+
+
+
 void ComputerMonitoringWidget::runMousePressAndHoldFeature( )
 {
 	m_mousePressAndHold.stop();
@@ -292,18 +299,20 @@ void ComputerMonitoringWidget::runMousePressAndHoldFeature( )
 		selectedInterfaces.count() < 2 &&
 		selectedInterfaces.first()->state() == ComputerControlInterface::State::Connected &&
 		selectedInterfaces.first()->hasValidFramebuffer() )
-   {
+	{
 		m_ignoreMousePressAndHoldEvent = true;
-		m_ignoreNumberOfMouseEvents = IgnoredNumberOfMouseEventsWhileHold;
+		resetIgnoreNumberOfMouseEvents();
 		delete m_computerZoomWidget;
 		m_computerZoomWidget = new ComputerZoomWidget( selectedInterfaces.first()  );
-   }
+		connect( m_computerZoomWidget, &ComputerZoomWidget::keypressInComputerZoomWidget, this, &ComputerMonitoringWidget::resetIgnoreNumberOfMouseEvents );
+	}
 }
 
 
 
 void ComputerMonitoringWidget::stopMousePressAndHoldFeature( )
 {
+	disconnect( m_computerZoomWidget, &ComputerZoomWidget::keypressInComputerZoomWidget, this, &ComputerMonitoringWidget::resetIgnoreNumberOfMouseEvents );
 	m_ignoreMousePressAndHoldEvent = false;
 	m_ignoreNumberOfMouseEvents = 0;
 	m_computerZoomWidget->close();

--- a/master/src/ComputerMonitoringWidget.h
+++ b/master/src/ComputerMonitoringWidget.h
@@ -53,6 +53,8 @@ public:
 		m_ignoreWheelEvent = enabled;
 	}
 
+	void resetIgnoreNumberOfMouseEvents( );
+
 	QTimer m_mousePressAndHold;
 
 private:

--- a/master/src/ComputerZoomWidget.h
+++ b/master/src/ComputerZoomWidget.h
@@ -39,14 +39,20 @@ public:
 	~ComputerZoomWidget() override;
 
 protected:
+	bool eventFilter( QObject* object, QEvent* event ) override;
+
 	void resizeEvent( QResizeEvent* event ) override;
+	void closeEvent( QCloseEvent* event ) override;
 
 private:
 	void updateSize();
 	void updateComputerZoomWidgetTitle();
 
-	void closeEvent( QCloseEvent* event ) override;
+	int m_currentScreen{-1};
 
 	VncViewWidget* m_vncView;
+
+Q_SIGNALS:
+	void keypressInComputerZoomWidget( );
 
 } ;


### PR DESCRIPTION
This is will add the ability to switch between student screens while the ComputerZoomWidgets mouse press and hold preview window is open. Press tab or backtab to navigate trough the different student screens and the scaled overview of all screens. This PR still contains some debugging output classified as vCritial, which will need to be removed or reclassified, before it can be merged.