### PR TITLE
linux: runProgramAsUser set gid as well

### DIFF
--- a/plugins/platform/linux/LinuxUserFunctions.cpp
+++ b/plugins/platform/linux/LinuxUserFunctions.cpp
@@ -454,6 +454,18 @@ uid_t LinuxUserFunctions::userIdFromName( const QString& username )
 	return 0;
 }
 
+gid_t LinuxUserFunctions::userGroupIdFromName( const QString& username )
+{
+	const auto pw_entry = getpwnam( username.toUtf8().constData() );
+
+	if( pw_entry )
+	{
+		return pw_entry->pw_gid;
+	}
+
+	return 0;
+}
+
 
 
 QVariant LinuxUserFunctions::getUserProperty(const QString& userPath, const QString& property, bool logErrors)

--- a/plugins/platform/linux/LinuxUserFunctions.h
+++ b/plugins/platform/linux/LinuxUserFunctions.h
@@ -50,6 +50,7 @@ public:
 	bool authenticate( const QString& username, const Password& password ) override;
 
 	static uid_t userIdFromName( const QString& username );
+	static gid_t userGroupIdFromName( const QString& username );
 
 	static QVariant getUserProperty(const QString& userPath, const QString& property, bool logErrors = true);
 


### PR DESCRIPTION
Programs were started with gid 0, which is unsafe and leads to unexpected
results, such as the inability to access the user's tmpdir.