### PR TITLE
Configurator: sort computers by user surname

### DIFF
--- a/configurator/src/MasterConfigurationPage.ui
+++ b/configurator/src/MasterConfigurationPage.ui
@@ -187,6 +187,11 @@
             </item>
             <item>
              <property name="text">
+              <string>Only last part of user name (hopefully surname)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
               <string>Only computer name</string>
              </property>
             </item>

--- a/configurator/src/MasterConfigurationPage.ui
+++ b/configurator/src/MasterConfigurationPage.ui
@@ -187,7 +187,7 @@
             </item>
             <item>
              <property name="text">
-              <string>Only last part of user name (hopefully surname)</string>
+              <string>Only last part of user name</string>
              </property>
             </item>
             <item>

--- a/core/src/ComputerListModel.h
+++ b/core/src/ComputerListModel.h
@@ -58,6 +58,7 @@ public:
 	enum class SortOrder {
 		ComputerAndUserName,
 		UserName,
+		LastPartOfUserName,
 		ComputerName,
 	};
 	Q_ENUM(SortOrder)

--- a/master/src/ComputerControlListModel.cpp
+++ b/master/src/ComputerControlListModel.cpp
@@ -581,9 +581,10 @@ QString ComputerControlListModel::computerSortRole( const ComputerControlInterfa
 		return controlInterface->userLoginName();
 	
 	case SortOrder::LastPartOfUserName:
-		if( controlInterface->userFullName().isEmpty() == false )
+		const QStringList parts = controlInterface->userFullName().split(QLatin1Char(' '), Qt::SkipEmptyParts);
+		if( parts.isEmpty() == false )
 		{
-			return controlInterface->userFullName().split(QLatin1Char(" "), Qt::SkipEmptyParts).constlast();
+			return parts.constLast();
 		}
 
 		return controlInterface->userLoginName();

--- a/master/src/ComputerControlListModel.cpp
+++ b/master/src/ComputerControlListModel.cpp
@@ -579,6 +579,14 @@ QString ComputerControlListModel::computerSortRole( const ComputerControlInterfa
 		}
 
 		return controlInterface->userLoginName();
+	
+	case SortOrder::LastPartOfUserName:
+		if( controlInterface->userFullName().isEmpty() == false )
+		{
+			return controlInterface->userFullName().split(QStringLiteral(" "), Qt::SkipEmptyParts).last();
+		}
+
+		return controlInterface->userLoginName();
 	}
 
 	return {};

--- a/master/src/ComputerControlListModel.cpp
+++ b/master/src/ComputerControlListModel.cpp
@@ -583,7 +583,7 @@ QString ComputerControlListModel::computerSortRole( const ComputerControlInterfa
 	case SortOrder::LastPartOfUserName:
 		if( controlInterface->userFullName().isEmpty() == false )
 		{
-			return controlInterface->userFullName().split(QStringLiteral(" "), Qt::SkipEmptyParts).last();
+			return controlInterface->userFullName().split(QLatin1Char(" "), Qt::SkipEmptyParts).constlast();
 		}
 
 		return controlInterface->userLoginName();

--- a/translations/veyon.ts
+++ b/translations/veyon.ts
@@ -3207,6 +3207,10 @@ The public key is used on client computers to authenticate incoming connection r
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Only last part of user name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Only computer name</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/veyon_fr.ts
+++ b/translations/veyon_fr.ts
@@ -3365,6 +3365,10 @@ La clé publique est utilisée sur les ordinateurs clients pour l&apos;authentif
         <translation>Uniquement le nom d&apos;utilisateur</translation>
     </message>
     <message>
+        <source>Only last part of user name</source>
+        <translation>Uniquement la dernière partie du nom d&apos;utilisateur</translation>
+    </message>
+    <message>
         <source>Only computer name</source>
         <translation>Nom d&apos;ordinateur seulement</translation>
     </message>


### PR DESCRIPTION
Veyon Master can sort computers by the name of the user logged into each machine. However, when the UserFullNames are of the form "FirstName LastName", this leads to them being sorted by first names, which is not usual in eg. High School, University, etc.

This adds an option in Configurator to have Master sort computers by the last part of UserFullName after splitting it on spaces.