### PR TITLE
re #1034 putting new option at end of list

### DIFF
--- a/configurator/src/MasterConfigurationPage.ui
+++ b/configurator/src/MasterConfigurationPage.ui
@@ -187,12 +187,12 @@
             </item>
             <item>
              <property name="text">
-              <string>Only last part of user name</string>
+              <string>Only computer name</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Only computer name</string>
+              <string>Only last part of user name</string>
              </property>
             </item>
            </widget>

--- a/core/src/ComputerListModel.h
+++ b/core/src/ComputerListModel.h
@@ -58,8 +58,8 @@ public:
 	enum class SortOrder {
 		ComputerAndUserName,
 		UserName,
-		LastPartOfUserName,
 		ComputerName,
+		LastPartOfUserName,
 	};
 	Q_ENUM(SortOrder)
 


### PR DESCRIPTION
It seems the order of options is not only a presentation question, but influences how options are stored (see https://github.com/veyon/veyon/pull/1034#issuecomment-2958983651). So this improves #1034 by putting the new option at the end.