### PR TITLE
master: setting autosize button off when size slider is moved

### DIFF
--- a/master/src/MainWindow.cpp
+++ b/master/src/MainWindow.cpp
@@ -216,12 +216,12 @@ MainWindow::MainWindow( VeyonMaster &masterCore, QWidget* parent ) :
 
 	connect( ui->gridSizeSlider, &QSlider::valueChanged,
 			 this, [this]( int size ) { ui->computerMonitoringWidget->setComputerScreenSize( size ); } );
-	connect( ui->gridSizeSlider, &QSlider::sliderMoved,
-			 this, [this]( int size ) {
-				 ui->computerMonitoringWidget->setAutoAdjustIconSize( false );
-				 m_master.userConfig().setAutoAdjustMonitoringIconSize( false );
-				 ui->autoAdjustComputerIconSizeButton->setChecked( false );
-			 } );	
+	connect(ui->gridSizeSlider, &QSlider::sliderMoved,
+			 this, [this](int size) {
+				 ui->computerMonitoringWidget->setAutoAdjustIconSize(false);
+				 m_master.userConfig().setAutoAdjustMonitoringIconSize(false);
+				 ui->autoAdjustComputerIconSizeButton->setChecked(false);
+			 });
 	connect( ui->computerMonitoringWidget, &ComputerMonitoringWidget::computerScreenSizeAdjusted,
 			 ui->gridSizeSlider, &QSlider::setValue );
 	connect( ui->autoAdjustComputerIconSizeButton, &QToolButton::toggled,


### PR DESCRIPTION
Veyon master has a slider to set the size of the previews in the main grid, and also a button to automatically set this size to fit the main windows dimensions.

When the autosize setting is on, moving the size slider sets it off, but the button in the GUI remains on (pressed). This means that to reactivate the autosize setting, one has to click the button twice.

This PR eschews that by setting off the button when the slider is moved by clicking and dragging it.

(however, it does not when the slider is given the focus then is moved using the keyboard ; using the ``sliderMoved`` event is not possible since that is also triggered when the autosize setting is set on and the size of the previews updated accordingly).