### PR TITLE
Add destination folder to File transfer dialog

### DIFF
--- a/plugins/filetransfer/FileTransferController.cpp
+++ b/plugins/filetransfer/FileTransferController.cpp
@@ -269,3 +269,8 @@ bool FileTransferController::allQueuesEmpty()
 
 	return true;
 }
+
+QString FileTransferController::destinationDirectory() const
+{
+	return m_plugin->destinationDirectory();
+}

--- a/plugins/filetransfer/FileTransferController.h
+++ b/plugins/filetransfer/FileTransferController.h
@@ -61,6 +61,8 @@ public:
 
 	bool isRunning() const;
 
+	QString destinationDirectory() const;
+
 Q_SIGNALS:
 	void errorOccured( const QString& message );
 	void filesChanged();

--- a/plugins/filetransfer/FileTransferDialog.cpp
+++ b/plugins/filetransfer/FileTransferDialog.cpp
@@ -41,6 +41,8 @@ FileTransferDialog::FileTransferDialog( FileTransferController* controller, QWid
 
 	ui->fileListView->setModel( m_listModel );
 
+	ui->leDestination->setText(controller->destinationDirectory());
+
 	connect( m_controller, &FileTransferController::progressChanged,
 			 this, &FileTransferDialog::updateProgress );
 

--- a/plugins/filetransfer/FileTransferDialog.ui
+++ b/plugins/filetransfer/FileTransferDialog.ui
@@ -3,6 +3,14 @@
  <author>Tobias Junghans</author>
  <class>FileTransferDialog</class>
  <widget class="QDialog" name="FileTransferDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>558</width>
+    <height>770</height>
+   </rect>
+  </property>
   <property name="windowTitle">
    <string>File transfer</string>
   </property>
@@ -77,6 +85,26 @@
        <widget class="QProgressBar" name="progressBar"/>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="labelDestination">
+     <property name="text">
+      <string>Destination folder</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="leDestination">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="toolTip">
+      <string>This can be set by an admin using Veyon Configurator</string>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item>

--- a/plugins/filetransfer/FileTransferPlugin.h
+++ b/plugins/filetransfer/FileTransferPlugin.h
@@ -115,6 +115,9 @@ public:
 
 	ConfigurationPage* createConfigurationPage() override;
 
+	QString destinationDirectory() const;
+
+
 Q_SIGNALS:
 	Q_INVOKABLE void acceptSelectedFiles( const QList<QUrl>& fileUrls );
 
@@ -124,7 +127,6 @@ private:
 		return m_lastFileTransferSourceDirectory;
 	}
 
-	QString destinationDirectory() const;
 
 	enum Commands
 	{


### PR DESCRIPTION
This adds a read-only item to the File transfer dialog to display the destination folder.

I added it for my ongoing investigation as to why setting that folder to some Windows network share (eg. ``P:\Downloads``) does not seem to work, but it should be generally useful because a teacher may need to remind this to pupils.

I have not tested it in a situation where we transfer files to multiple computers at the same time.

This is implemented by making ``destinationDirectory()`` public in ``FileTransferPlugin`` and adding a public method of the same name in ``FileTransferController`` (to avoid a adding a direct dependency to ``FileTransferPlugin`` in ``FileTransferDialog``).