### PR TITLE
LDAP: mention FreeIPA in the distinguished-name group member option

### DIFF
--- a/plugins/ldap/LdapConfigurationPage.ui
+++ b/plugins/ldap/LdapConfigurationPage.ui
@@ -881,7 +881,7 @@
           <item>
            <widget class="QRadioButton" name="identifyGroupMembersByDN">
             <property name="text">
-             <string>Distinguished name (Samba/AD)</string>
+             <string>Distinguished name (Samba/AD/FreeIPA)</string>
             </property>
             <property name="checked">
              <bool>true</bool>


### PR DESCRIPTION
FreeIPA (389 Directory Server) stores group membership in the `member` attribute as distinguished names, exactly like Samba/AD — not as login names like a plain OpenLDAP setup.

The "Group member identification" radio button is labelled **"Distinguished name (Samba/AD)"**, so FreeIPA administrators tend to pick the other option (*"... user login name ... (OpenLDAP)"*) instead. With that scheme the *groups of user* query builds the filter `member=<login>`, which never matches the DN values stored by FreeIPA, and group-based access control silently stops working.

This was reported downstream as [ALT bug #51651](https://bugzilla.altlinux.org/51651): the LDAP integration test fails until the user switches group member identification to "Distinguished name".

This change adds FreeIPA to the label so the correct scheme is obvious. UI-string-only change; translations are left to be picked up by the usual `lupdate` / Weblate workflow.