### PR TITLE
Configurator: auto-increment default names for new objects

### DIFF
--- a/core/src/ObjectManager.h
+++ b/core/src/ObjectManager.h
@@ -231,6 +231,36 @@ public:
 		return T();
 	}
 
+	bool hasName(const typename T::Name& name) const
+	{
+		for (auto it = m_objects.constBegin(); it != m_objects.constEnd(); ++it)
+		{
+			if (T(it->toObject()).name() == name)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	typename T::Name generateUniqueName(const typename T::Name& baseName) const
+	{
+		if (hasName(baseName) == false)
+		{
+			return baseName;
+		}
+
+		for (int suffix = 2; ; ++suffix)
+		{
+			const auto candidate = QStringLiteral("%1 %2").arg(baseName).arg(suffix);
+			if (hasName(candidate) == false)
+			{
+				return candidate;
+			}
+		}
+	}
+
 private:
 	QJsonArray m_objects;
 

--- a/plugins/builtindirectory/BuiltinDirectoryConfigurationPage.cpp
+++ b/plugins/builtindirectory/BuiltinDirectoryConfigurationPage.cpp
@@ -78,8 +78,9 @@ void BuiltinDirectoryConfigurationPage::applyConfiguration()
 void BuiltinDirectoryConfigurationPage::addLocation()
 {
 	ObjectManager<NetworkObject> objectManager( m_configuration.networkObjects() );
-	objectManager.add( NetworkObject( NetworkObject::Type::Location, tr( "New location" ),
-									  {}, {}, {}, QUuid::createUuid() ) );
+	objectManager.add(NetworkObject(NetworkObject::Type::Location,
+									objectManager.generateUniqueName(tr("New location")),
+									{}, {}, {}, QUuid::createUuid()));
 	m_configuration.setNetworkObjects( objectManager.objects() );
 
 	populateLocations();
@@ -166,10 +167,11 @@ void BuiltinDirectoryConfigurationPage::addComputer()
 	}
 
 	ObjectManager<NetworkObject> objectManager( m_configuration.networkObjects() );
-	objectManager.add( NetworkObject( NetworkObject::Type::Host, tr( "New computer" ),
-									  {}, {}, {},
-									  QUuid::createUuid(),
-									  currentLocationUid ) );
+	objectManager.add(NetworkObject(NetworkObject::Type::Host,
+									objectManager.generateUniqueName(tr("New computer")),
+									{}, {}, {},
+									QUuid::createUuid(),
+									currentLocationUid));
 	m_configuration.setNetworkObjects( objectManager.objects() );
 
 	populateComputers();

--- a/plugins/desktopservices/DesktopServicesConfigurationPage.cpp
+++ b/plugins/desktopservices/DesktopServicesConfigurationPage.cpp
@@ -135,7 +135,7 @@ void DesktopServicesConfigurationPage::addServiceObject( QTableWidget* tableWidg
 														 const QString& name, QJsonArray& objects )
 {
 	ObjectManager<DesktopServiceObject> objectManager( objects );
-	objectManager.add( DesktopServiceObject( type, name ) );
+	objectManager.add(DesktopServiceObject(type, objectManager.generateUniqueName(name)));
 	objects = objectManager.objects();
 
 	loadObjects( objects, tableWidget );


### PR DESCRIPTION
## Problem

In the Veyon Configurator, creating multiple objects of the same kind in a
row gives every new object the identical default name:

- **Locations and Computers** page — every new location is named
  "New location", every new computer "New computer".
- **Desktop services** page — every new application is named
  "New application", every new website "New website".

The result is several indistinguishable rows with the same name, which is
easy to confuse and forces the user to rename each one manually before the
list makes sense.

## Change

Add `ObjectManager::generateUniqueName()`. It returns the base name when it
is still unused, and otherwise appends an incrementing numeric suffix
("New location 2", "New location 3", ...) until a free name is found. A
small `hasName()` helper backs it.

`generateUniqueName()` is then used when adding objects in:

- `BuiltinDirectoryConfigurationPage` — `addLocation()`, `addComputer()`
- `DesktopServicesConfigurationPage` — `addServiceObject()` (applications
  and websites)

## Notes

- `findByName()` was intentionally not reused for the existence check: for a
  missing object it returns a default-constructed `T()`, and `NetworkObject`
  derives a non-null UID from its (empty) name, so a "not found" result is
  not reliably distinguishable. `hasName()` checks names directly instead.
- Reported downstream as ALT Linux bug
  [#41420](https://bugzilla.altlinux.org/41420).

## Testing

Verified in the configurator: adding many locations and computers in a row
now yields "New location", "New location 2", ... "New location 11" and the
matching computer names, with no duplicates.
