### PR TITLE
WebAPI: make the plugin build explicit via WITH_WEBAPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(WITH_THREAD_SANITIZER "Build with thread sanitizer" OFF)
 option(WITH_UB_SANITIZER "Build with undefined behavior sanitizer" OFF)
 option(WITH_FUZZERS "Build LLVM fuzzer tests (implies WITH_TESTS=ON)" OFF)
 option(WITH_BUILTIN_LIBVNC "Build with built-in LibVNCServer/Client" OFF)
+option(WITH_WEBAPI "Build WebAPI plugin" ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/plugins/webapi/CMakeLists.txt
+++ b/plugins/webapi/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT WITH_WEBAPI)
+	return()
+endif()
+
 if(WITH_QT6)
 	find_package(Qt6 COMPONENTS HttpServer)
 else()
@@ -42,6 +46,6 @@ if(Qt6HttpServer_DIR OR Qt5HttpServer_DIR OR (Qt5Core_VERSION VERSION_GREATER 5.
 
 else()
 
-	message(WARNING "Neither Qt6HttpServer nor Qt5HttpServer nor Qt >= 5.12 with private headers found - omitting WebAPI plugin from build")
+	message(FATAL_ERROR "WebAPI plugin is enabled (WITH_WEBAPI=ON) but no Qt HTTP server module was found. Install the Qt HttpServer development package (Qt6::HttpServer or Qt5::HttpServer), or pass -DWITH_WEBAPI=OFF to disable the plugin.")
 
 endif()


### PR DESCRIPTION
## Problem

The WebAPI plugin's CMake silently emits a `WARNING` and omits the plugin from the build whenever no Qt HTTP server module is found:

```
message(WARNING "Neither Qt6HttpServer nor Qt5HttpServer nor Qt >= 5.12 with private headers found - omitting WebAPI plugin from build")
```

A packager who forgets the Qt HttpServer development dependency therefore gets a quietly incomplete package. The missing plugin is only noticed much later by end users — e.g. ALT Linux downstream bug report <https://bugzilla.altlinux.org/56194>, where WebAPI was simply absent from `veyon-cli plugin list` with no build-time indication.

## Change

* Add a `WITH_WEBAPI` option (default `ON`, consistent with the other `WITH_*` options in the top-level `CMakeLists.txt`).
* Turn the silent omission into a `FATAL_ERROR` with an actionable message: when the plugin is requested but no Qt HTTP server is available, the configure step now fails.
* Skipping the plugin requires an explicit `-DWITH_WEBAPI=OFF`.

## Behaviour

| `WITH_WEBAPI` | Qt HTTP server | Result |
|---|---|---|
| `ON` (default) | found | plugin built |
| `ON` | missing | configure fails with `FATAL_ERROR` |
| `OFF` | — | plugin skipped, no diagnostics |

No functional change to the plugin itself.
