### PR TITLE
Configurator: hide x11vnc parameters label in standard view

### DIFF
--- a/plugins/vncserver/x11vnc-builtin/X11VncConfigurationWidget.cpp
+++ b/plugins/vncserver/x11vnc-builtin/X11VncConfigurationWidget.cpp
@@ -35,6 +35,11 @@ X11VncConfigurationWidget::X11VncConfigurationWidget( X11VncConfiguration& confi
 {
 	ui->setupUi( this );
 
+	// all properties of this widget are advanced - mark the whole widget as
+	// advanced so its static labels are hidden together with the input fields
+	// in standard view mode
+	Configuration::UiMapping::setFlags( this, Configuration::Property::Flag::Advanced );
+
 	FOREACH_X11VNC_CONFIG_PROPERTY(INIT_WIDGET_FROM_PROPERTY);
 	FOREACH_X11VNC_CONFIG_PROPERTY(CONNECT_WIDGET_TO_PROPERTY);
 }


### PR DESCRIPTION
## Problem

On the **Service** tab of the configurator, when the builtin x11vnc server is selected, the *"Custom x11vnc parameters:"* label is shown without its input field in **standard** view mode. The line edit only appears after switching to **advanced** view via the *View* menu, leaving a dangling label in standard mode.

## Cause

Both x11vnc properties in `X11VncConfiguration.h` carry `Configuration::Property::Flag::Advanced`:

```c
OP( ..., isXDamageDisabled, ..., Configuration::Property::Flag::Advanced )
OP( ..., extraArguments,    ..., Configuration::Property::Flag::Advanced )
```

`MainWindow::switchToStandardView()` hides widgets carrying the `Advanced` flag, but the flag is only set on the widgets bound to a property (`UiMapping::setFlags(ui->get, flags)`). The static `QLabel` for the extra-arguments field comes from the `.ui` file and is bound to no property, so it never receives the flag and stays visible while its `QLineEdit` is hidden.

## Fix

Mark the whole `X11VncConfigurationWidget` as advanced in its constructor — the same approach `DemoConfigurationPage` already uses for its page. The entire widget (label included) is then hidden in standard view and shown again in advanced view.

Reported downstream as ALT Linux bug https://bugzilla.altlinux.org/52928.