### PR TITLE
Demo: don't lock the master computer when sharing a user's screen fullscreen

### DIFF
--- a/plugins/demo/DemoFeaturePlugin.cpp
+++ b/plugins/demo/DemoFeaturePlugin.cpp
@@ -229,6 +229,22 @@ bool DemoFeaturePlugin::startFeature( VeyonMasterInterface& master, const Featur
 		auto userDemoControlInterfaces = computerControlInterfaces;
 		userDemoControlInterfaces.removeAll( demoServerInterface );
 
+		// never send a (potentially fullscreen) demo client to the master
+		// computer itself: it is listed as a regular room computer but has to
+		// keep control over the running demonstration - it receives a dedicated
+		// window demo below instead
+		for (auto it = userDemoControlInterfaces.begin(); it != userDemoControlInterfaces.end(); )
+		{
+			if (HostAddress(HostAddress::parseHost((*it)->computer().hostName())).isLocalHost())
+			{
+				it = userDemoControlInterfaces.erase(it);
+			}
+			else
+			{
+				++it;
+			}
+		}
+
 		const QVariantMap demoClientArgs{
 			{ argToString(Argument::DemoServerHost), HostAddress::parseHost(demoServerHost) },
 			{ argToString(Argument::DemoServerPort), demoServerPort },


### PR DESCRIPTION
## Problem

When the master computer is itself listed among the room computers — a common setup in labs where one or more teacher stations are added to the location — starting **Demo → Share selected user's screen in fullscreen mode** locks the master itself.

`startFeature()` for the user-screen demo sends a fullscreen demo client to every room computer except the selected one (`userDemoControlInterfaces`), and *separately* sends a dedicated **window** demo to the master's own local session so the teacher keeps control. But the master's own computer is also part of `userDemoControlInterfaces`, so it additionally receives the fullscreen client. The fullscreen `LockWidget` grabs keyboard and mouse and covers Veyon Master — the teacher can no longer switch the demonstrated user or even stop the demo. With two teacher stations, both get locked.

## Steps to reproduce

1. Add the teacher/master computer to the room's computer list.
2. Open Veyon Master, select a student.
3. Demo → *Share selected user's screen in fullscreen mode*.
4. The master's own screen is locked fullscreen and Veyon Master becomes unreachable.

## Fix

Exclude the local host from the fullscreen demo client broadcast. The master already receives the dedicated window demo via its local session interface — that is what lets the teacher monitor the demonstration without being locked.

Verified on ALT Education (KDE Plasma 6 / X11): after the change the presenting teacher's machine keeps a usable Veyon Master and can stop the demo, while student computers still get the fullscreen demo as before.

Downstream report: https://bugzilla.altlinux.org/41102