### PR TITLE
Wayland support: PipeWire VNC backend and platform integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ option(WITH_THREAD_SANITIZER "Build with thread sanitizer" OFF)
 option(WITH_UB_SANITIZER "Build with undefined behavior sanitizer" OFF)
 option(WITH_FUZZERS "Build LLVM fuzzer tests (implies WITH_TESTS=ON)" OFF)
 option(WITH_BUILTIN_LIBVNC "Build with built-in LibVNCServer/Client" OFF)
+
+option(VEYON_USE_BUILTIN_LIBVNC "Build with bundled LibVNCServer instead of system one" OFF)
 option(WITH_WEBAPI "Build WebAPI plugin" ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -15,7 +15,7 @@ set(core_RESOURCES
 	${CMAKE_CURRENT_BINARY_DIR}/builddata.qrc
 	)
 
-if(NOT WITH_BUILTIN_LIBVNC)
+if(NOT WITH_BUILTIN_LIBVNC AND NOT VEYON_USE_BUILTIN_LIBVNC)
 	find_package(LibVNCClient 0.9.14)
 endif()
 

--- a/plugins/platform/linux/LinuxCoreFunctions.cpp
+++ b/plugins/platform/linux/LinuxCoreFunctions.cpp
@@ -22,8 +22,12 @@
  *
  */
 
+#include <QCoreApplication>
 #include <QElapsedTimer>
 #include <QFileInfo>
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QDBusObjectPath>
 #include <QDBusPendingCall>
 #include <QProcess>
 #include <QProcessEnvironment>
@@ -45,6 +49,13 @@
 
 #include <X11/XKBlib.h>
 #include <X11/extensions/dpms.h>
+
+
+LinuxCoreFunctions::LinuxCoreFunctions() :
+	m_isWaylandSession(qEnvironmentVariableIsSet("WAYLAND_DISPLAY"))
+{
+}
+
 
 
 bool LinuxCoreFunctions::prepareSessionBusAccess()
@@ -146,6 +157,13 @@ void LinuxCoreFunctions::raiseWindow( QWidget* widget, bool stayOnTop )
 
 void LinuxCoreFunctions::disableScreenSaver()
 {
+	// On Wayland use DBus-based inhibition
+	if (m_isWaylandSession)
+	{
+		disableScreenSaverWayland();
+		return;
+	}
+
 	auto display = XOpenDisplay( nullptr );
 
 	// query and disable screen saver
@@ -186,6 +204,13 @@ void LinuxCoreFunctions::disableScreenSaver()
 
 void LinuxCoreFunctions::restoreScreenSaverSettings()
 {
+	// On Wayland use DBus-based restoration
+	if (m_isWaylandSession)
+	{
+		restoreScreenSaverSettingsWayland();
+		return;
+	}
+
 	auto display = XOpenDisplay( nullptr );
 
 	// restore screensaver settings
@@ -210,6 +235,99 @@ void LinuxCoreFunctions::restoreScreenSaverSettings()
 
 	XFlush( display );
 	XCloseDisplay( display );
+}
+
+
+
+void LinuxCoreFunctions::disableScreenSaverWayland()
+{
+	// Try org.freedesktop.portal.Inhibit first (xdg-desktop-portal, works on all DEs)
+	const auto appName = QCoreApplication::applicationName();
+
+	QDBusMessage inhibitPortal = QDBusMessage::createMethodCall(
+		QStringLiteral("org.freedesktop.portal.Desktop"),
+		QStringLiteral("/org/freedesktop/portal/desktop"),
+		QStringLiteral("org.freedesktop.portal.Inhibit"),
+		QStringLiteral("Inhibit"));
+	inhibitPortal.setArguments({
+		QVariant::fromValue(QDBusObjectPath(QStringLiteral("/"))),
+		QVariant::fromValue(appName),
+		QVariant::fromValue(QStringLiteral("remote-desktop")),
+		QVariant::fromValue(QVariantMap{})
+	});
+	QDBusMessage reply = QDBusConnection::sessionBus().call(inhibitPortal, QDBus::BlockWithGui, 2000);
+
+	if (reply.type() == QDBusMessage::ReplyMessage)
+	{
+		m_waylandInhibitCookie = reply.arguments().value(0).toUInt();
+		vDebug() << "Screen saver inhibited via portal, cookie:" << m_waylandInhibitCookie;
+		return;
+	}
+
+	vDebug() << "Portal Inhibit not available, trying org.freedesktop.ScreenSaver";
+
+	// Fallback: org.freedesktop.ScreenSaver (older DEs)
+	QDBusMessage inhibitFreeDesktop = QDBusMessage::createMethodCall(
+		QStringLiteral("org.freedesktop.ScreenSaver"),
+		QStringLiteral("/ScreenSaver"),
+		QStringLiteral("org.freedesktop.ScreenSaver"),
+		QStringLiteral("Inhibit"));
+	inhibitFreeDesktop.setArguments({
+		QVariant::fromValue(appName),
+		QVariant::fromValue(QStringLiteral("Veyon remote desktop session"))
+	});
+	QDBusMessage reply2 = QDBusConnection::sessionBus().call(inhibitFreeDesktop, QDBus::BlockWithGui, 2000);
+
+	if (reply2.type() == QDBusMessage::ReplyMessage)
+	{
+		m_waylandInhibitCookie = reply2.arguments().value(0).toUInt();
+		vDebug() << "Screen saver inhibited via org.freedesktop.ScreenSaver, cookie:" << m_waylandInhibitCookie;
+		return;
+	}
+
+	vWarning() << "Could not inhibit screen saver on Wayland - no portal or DBus interface available";
+}
+
+
+
+void LinuxCoreFunctions::restoreScreenSaverSettingsWayland()
+{
+	if (m_waylandInhibitCookie == 0)
+	{
+		return;
+	}
+
+	// Try portal UnInhibit first
+	QDBusMessage unInhibitPortal = QDBusMessage::createMethodCall(
+		QStringLiteral("org.freedesktop.portal.Desktop"),
+		QStringLiteral("/org/freedesktop/portal/desktop"),
+		QStringLiteral("org.freedesktop.portal.Inhibit"),
+		QStringLiteral("UnInhibit"));
+	unInhibitPortal.setArguments({
+		QVariant::fromValue(m_waylandInhibitCookie)
+	});
+	QDBusMessage reply = QDBusConnection::sessionBus().call(unInhibitPortal, QDBus::BlockWithGui, 2000);
+
+	if (reply.type() == QDBusMessage::ReplyMessage || reply.type() == QDBusMessage::ErrorMessage)
+	{
+		vDebug() << "Screen saver restored via portal";
+		m_waylandInhibitCookie = 0;
+		return;
+	}
+
+	// Fallback: org.freedesktop.ScreenSaver UnInhibit
+	QDBusMessage unInhibitFreeDesktop = QDBusMessage::createMethodCall(
+		QStringLiteral("org.freedesktop.ScreenSaver"),
+		QStringLiteral("/ScreenSaver"),
+		QStringLiteral("org.freedesktop.ScreenSaver"),
+		QStringLiteral("UnInhibit"));
+	unInhibitFreeDesktop.setArguments({
+		QVariant::fromValue(m_waylandInhibitCookie)
+	});
+	QDBusConnection::sessionBus().call(unInhibitFreeDesktop, QDBus::BlockWithGui, 2000);
+
+	m_waylandInhibitCookie = 0;
+	vDebug() << "Screen saver restored via org.freedesktop.ScreenSaver";
 }
 
 

--- a/plugins/platform/linux/LinuxCoreFunctions.h
+++ b/plugins/platform/linux/LinuxCoreFunctions.h
@@ -24,7 +24,10 @@
 
 #pragma once
 
+#include <QDBusConnection>
 #include <QDBusInterface>
+#include <QDBusMessage>
+#include <QDBusPendingCall>
 #include <QSharedPointer>
 
 #include "PlatformCoreFunctions.h"
@@ -44,7 +47,7 @@ struct proc_t;
 class LinuxCoreFunctions : public PlatformCoreFunctions
 {
 public:
-	LinuxCoreFunctions() = default;
+	LinuxCoreFunctions();
 
 	bool applyConfiguration() override;
 
@@ -109,5 +112,13 @@ private:
 	unsigned short m_dpmsStandbyTimeout{0};
 	unsigned short m_dpmsSuspendTimeout{0};
 	unsigned short m_dpmsOffTimeout{0};
+
+	// Wayland screen saver inhibition via DBus
+	const bool m_isWaylandSession;
+	static constexpr auto WaylandScreenSaverInhibitCookie = 0;
+	unsigned m_waylandInhibitCookie{0};
+
+	void disableScreenSaverWayland();
+	void restoreScreenSaverSettingsWayland();
 
 };

--- a/plugins/platform/linux/LinuxInputDeviceFunctions.cpp
+++ b/plugins/platform/linux/LinuxInputDeviceFunctions.cpp
@@ -22,33 +22,65 @@
  *
  */
 
+#include <QDir>
+#include <QFile>
+
 #include "PlatformServiceFunctions.h"
 #include "LinuxInputDeviceFunctions.h"
 #include "LinuxKeyboardShortcutTrapper.h"
 
+
+LinuxInputDeviceFunctions::LinuxInputDeviceFunctions() :
+	m_isWaylandSession(qEnvironmentVariableIsSet("WAYLAND_DISPLAY"))
+{
+}
+
 #include <X11/XKBlib.h>
+
+#include <fcntl.h>
+#include <linux/input.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
 
 
 void LinuxInputDeviceFunctions::enableInputDevices()
 {
-	if( m_inputDevicesDisabled )
+	if( m_inputDevicesDisabled == false )
+	{
+		return;
+	}
+
+	if (m_isWaylandSession)
+	{
+		enableInputDevicesWayland();
+	}
+	else
 	{
 		restoreKeyMapTable();
-
-		m_inputDevicesDisabled = false;
 	}
+
+	m_inputDevicesDisabled = false;
 }
 
 
 
 void LinuxInputDeviceFunctions::disableInputDevices()
 {
-	if( m_inputDevicesDisabled == false )
+	if( m_inputDevicesDisabled )
+	{
+		return;
+	}
+
+	if (m_isWaylandSession)
+	{
+		disableInputDevicesWayland();
+	}
+	else
 	{
 		setEmptyKeyMapTable();
-
-		m_inputDevicesDisabled = true;
 	}
+
+	m_inputDevicesDisabled = true;
 }
 
 
@@ -100,4 +132,86 @@ void LinuxInputDeviceFunctions::restoreKeyMapTable()
 
 	XFree( m_origKeyTable );
 	m_origKeyTable = nullptr;
+}
+
+
+
+// ---------------------------------------------------------------------------
+// Wayland input device blocking via evdev EVIOCGRAB
+// ---------------------------------------------------------------------------
+
+int LinuxInputDeviceFunctions::openAndGrabInputDevice(const QString& path)
+{
+	const int fd = ::open( path.toUtf8().constData(), O_RDWR | O_NONBLOCK );
+	if( fd < 0 )
+	{
+		return -1;
+	}
+
+	// Try to grab the device exclusively. This prevents Wayland/compositor
+	// from receiving events from this device while we hold the grab.
+	if( ::ioctl( fd, EVIOCGRAB, reinterpret_cast<void*>( 1L ) ) < 0 )
+	{
+		::close( fd );
+		return -1;
+	}
+
+	return fd;
+}
+
+
+
+void LinuxInputDeviceFunctions::disableInputDevicesWayland()
+{
+	// Close any previously grabbed devices first
+	enableInputDevicesWayland();
+
+	const QDir inputDir( QStringLiteral("/dev/input") );
+	if( inputDir.exists() == false )
+	{
+		vWarning() << "No /dev/input directory found - cannot grab input devices on Wayland";
+		return;
+	}
+
+	const auto eventFiles = inputDir.entryList( { QStringLiteral("event*") }, QDir::System | QDir::Files );
+	for( const auto& eventFile : eventFiles )
+	{
+		const auto devicePath = inputDir.absoluteFilePath( eventFile );
+
+		// Skip touchpads and other non-keyboard devices? We grab all input
+		// devices to ensure complete input blocking for classroom control.
+		const int fd = openAndGrabInputDevice( devicePath );
+		if( fd >= 0 )
+		{
+			m_grabbedDeviceFds.append( fd );
+			vDebug() << "Grabbed input device:" << devicePath;
+		}
+	}
+
+	if( m_grabbedDeviceFds.isEmpty() )
+	{
+		vWarning() << "Could not grab any input device - you might need to run as root";
+	}
+	else
+	{
+		vInfo() << "Grabbed" << m_grabbedDeviceFds.size() << "input devices on Wayland";
+	}
+}
+
+
+
+void LinuxInputDeviceFunctions::enableInputDevicesWayland()
+{
+	for( const auto fd : std::as_const( m_grabbedDeviceFds ) )
+	{
+		// Release the grab
+		if( fd >= 0 )
+		{
+			::ioctl( fd, EVIOCGRAB, reinterpret_cast<void*>( 0L ) );
+			::close( fd );
+		}
+	}
+
+	m_grabbedDeviceFds.clear();
+	vDebug() << "Released all grabbed input devices";
 }

--- a/plugins/platform/linux/LinuxInputDeviceFunctions.h
+++ b/plugins/platform/linux/LinuxInputDeviceFunctions.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <QList>
+
 #include "PlatformInputDeviceFunctions.h"
 
 // clazy:excludeall=copyable-polymorphic
@@ -31,7 +33,7 @@
 class LinuxInputDeviceFunctions : public PlatformInputDeviceFunctions
 {
 public:
-	LinuxInputDeviceFunctions() = default;
+	LinuxInputDeviceFunctions();
 	virtual ~LinuxInputDeviceFunctions() = default;
 
 	void enableInputDevices() override;
@@ -43,11 +45,21 @@ private:
 	void setEmptyKeyMapTable();
 	void restoreKeyMapTable();
 
+	// Wayland input device blocking via uinput + evdev grab
+	void disableInputDevicesWayland();
+	void enableInputDevicesWayland();
+	int openAndGrabInputDevice(const QString& path);
+
 	bool m_inputDevicesDisabled{false};
 	void* m_origKeyTable{nullptr};
 	int m_keyCodeMin{0};
 	int m_keyCodeMax{0};
 	int m_keyCodeCount{0};
 	int m_keySymsPerKeyCode{0};
+
+	// Wayland: grabbed input device FDs (owned, need close)
+	QList<int> m_grabbedDeviceFds;
+
+	const bool m_isWaylandSession;
 
 };

--- a/plugins/platform/linux/LinuxKeyboardInput.cpp
+++ b/plugins/platform/linux/LinuxKeyboardInput.cpp
@@ -23,32 +23,65 @@
  */
 
 #include <QThread>
+#include <QProcessEnvironment>
 
+#include "VeyonCore.h"
 #include "LinuxKeyboardInput.h"
 
 #include <X11/Xlib.h>
 
 #include <fakekey/fakekey.h>
 
+#include <fcntl.h>
+#include <linux/input.h>
+#include <linux/uinput.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
 
 LinuxKeyboardInput::LinuxKeyboardInput() :
-	m_display( XOpenDisplay( nullptr ) ),
-	m_fakeKeyHandle( fakekey_init( m_display ) )
+	m_isWaylandSession(qEnvironmentVariableIsSet("WAYLAND_DISPLAY"))
 {
+	if (m_isWaylandSession)
+	{
+		initUinput();
+	}
+	else
+	{
+		m_display = XOpenDisplay( nullptr );
+		m_fakeKeyHandle = fakekey_init( m_display );
+	}
 }
 
 
 
 LinuxKeyboardInput::~LinuxKeyboardInput()
 {
-	free( m_fakeKeyHandle );
-	XCloseDisplay( m_display );
+	if( m_uinputAvailable )
+	{
+		cleanupUinput();
+	}
+	else
+	{
+		free( m_fakeKeyHandle );
+		XCloseDisplay( m_display );
+	}
 }
 
 
 
 void LinuxKeyboardInput::pressAndReleaseKey( uint32_t keysym )
 {
+	if( m_uinputAvailable )
+	{
+		const auto linuxKeycode = keysymToLinuxKeycode( keysym );
+		if( linuxKeycode >= 0 )
+		{
+			pressAndReleaseKeyUinput( static_cast<uint32_t>( linuxKeycode ) );
+		}
+		return;
+	}
+
 	fakekey_press_keysym( m_fakeKeyHandle, keysym, 0 );
 	fakekey_release( m_fakeKeyHandle );
 }
@@ -57,6 +90,12 @@ void LinuxKeyboardInput::pressAndReleaseKey( uint32_t keysym )
 
 void LinuxKeyboardInput::pressAndReleaseKey( const QByteArray& utf8Data )
 {
+	if( m_uinputAvailable )
+	{
+		pressAndReleaseKeyUinputUtf8( utf8Data );
+		return;
+	}
+
 	fakekey_press( m_fakeKeyHandle, reinterpret_cast<const unsigned char *>( utf8Data.constData() ), utf8Data.size(), 0 );
 	fakekey_release( m_fakeKeyHandle );
 }
@@ -69,5 +108,324 @@ void LinuxKeyboardInput::sendString(const QString& string, int keyPressInterval)
 	{
 		pressAndReleaseKey( string.mid( i, 1 ).toUtf8() );
 		QThread::msleep(keyPressInterval);
+	}
+}
+
+
+
+void LinuxKeyboardInput::initUinput()
+{
+	m_uinputFd = ::open( "/dev/uinput", O_WRONLY | O_NONBLOCK );
+	if( m_uinputFd < 0 )
+	{
+		m_uinputFd = ::open( "/dev/input/uinput", O_WRONLY | O_NONBLOCK );
+	}
+
+	if( m_uinputFd < 0 )
+	{
+		vWarning() << "uinput not available";
+		m_uinputAvailable = false;
+		return;
+	}
+
+	::ioctl( m_uinputFd, UI_SET_EVBIT, EV_KEY );
+	::ioctl( m_uinputFd, UI_SET_EVBIT, EV_SYN );
+	for( int key = 0; key < KEY_MAX; ++key )
+	{
+		::ioctl( m_uinputFd, UI_SET_KEYBIT, key );
+	}
+
+	struct uinput_setup usetup;
+	std::memset( &usetup, 0, sizeof( usetup ) );
+	usetup.id.bustype = BUS_USB;
+	usetup.id.vendor  = 0x1d6b;
+	usetup.id.product = 0x0001;
+	std::strncpy( usetup.name, "Veyon Virtual Keyboard", sizeof( usetup.name ) - 1 );
+
+	if( ::ioctl( m_uinputFd, UI_DEV_SETUP, &usetup ) < 0 ||
+		::ioctl( m_uinputFd, UI_DEV_CREATE ) < 0 )
+	{
+		vWarning() << "uinput create failed";
+		::close( m_uinputFd );
+		m_uinputFd = -1;
+		m_uinputAvailable = false;
+		return;
+	}
+
+	m_uinputAvailable = true;
+}
+
+
+
+void LinuxKeyboardInput::cleanupUinput()
+{
+	if( m_uinputFd >= 0 )
+	{
+		::ioctl( m_uinputFd, UI_DEV_DESTROY );
+		::close( m_uinputFd );
+		m_uinputFd = -1;
+	}
+	m_uinputAvailable = false;
+}
+
+
+
+void LinuxKeyboardInput::pressAndReleaseKeyUinput( uint32_t linuxKeycode )
+{
+	if( m_uinputFd < 0 )
+	{
+		return;
+	}
+
+	struct input_event ev;
+	std::memset( &ev, 0, sizeof( ev ) );
+
+	ev.type = EV_KEY; ev.code = linuxKeycode; ev.value = 1;
+	::write( m_uinputFd, &ev, sizeof( ev ) );
+	ev.type = EV_SYN; ev.code = SYN_REPORT; ev.value = 0;
+	::write( m_uinputFd, &ev, sizeof( ev ) );
+
+	ev.type = EV_KEY; ev.code = linuxKeycode; ev.value = 0;
+	::write( m_uinputFd, &ev, sizeof( ev ) );
+	ev.type = EV_SYN; ev.code = SYN_REPORT; ev.value = 0;
+	::write( m_uinputFd, &ev, sizeof( ev ) );
+}
+
+
+
+void LinuxKeyboardInput::pressAndReleaseKeyUinputUtf8( const QByteArray& utf8Data )
+{
+	const auto linuxKeycode = utf8ToLinuxKeycode( utf8Data );
+	if( linuxKeycode >= 0 )
+	{
+		pressAndReleaseKeyUinput( static_cast<uint32_t>( linuxKeycode ) );
+	}
+}
+
+
+#define XK_LATIN1
+#define XK_MISCELLANY
+#define XK_XKB_KEYS
+#include <X11/keysymdef.h>
+
+
+int LinuxKeyboardInput::keysymToLinuxKeycode( uint32_t keysym )
+{
+	switch( keysym )
+	{
+	case XK_Escape:       return KEY_ESC;
+	case XK_1:            return KEY_1;
+	case XK_2:            return KEY_2;
+	case XK_3:            return KEY_3;
+	case XK_4:            return KEY_4;
+	case XK_5:            return KEY_5;
+	case XK_6:            return KEY_6;
+	case XK_7:            return KEY_7;
+	case XK_8:            return KEY_8;
+	case XK_9:            return KEY_9;
+	case XK_0:            return KEY_0;
+	case XK_minus:        return KEY_MINUS;
+	case XK_equal:        return KEY_EQUAL;
+	case XK_BackSpace:    return KEY_BACKSPACE;
+	case XK_Tab:          return KEY_TAB;
+	case XK_q:            return KEY_Q;
+	case XK_w:            return KEY_W;
+	case XK_e:            return KEY_E;
+	case XK_r:            return KEY_R;
+	case XK_t:            return KEY_T;
+	case XK_y:            return KEY_Y;
+	case XK_u:            return KEY_U;
+	case XK_i:            return KEY_I;
+	case XK_o:            return KEY_O;
+	case XK_p:            return KEY_P;
+	case XK_bracketleft:  return KEY_LEFTBRACE;
+	case XK_bracketright: return KEY_RIGHTBRACE;
+	case XK_Return:       return KEY_ENTER;
+	case XK_Control_L:    return KEY_LEFTCTRL;
+	case XK_a:            return KEY_A;
+	case XK_s:            return KEY_S;
+	case XK_d:            return KEY_D;
+	case XK_f:            return KEY_F;
+	case XK_g:            return KEY_G;
+	case XK_h:            return KEY_H;
+	case XK_j:            return KEY_J;
+	case XK_k:            return KEY_K;
+	case XK_l:            return KEY_L;
+	case XK_semicolon:    return KEY_SEMICOLON;
+	case XK_apostrophe:   return KEY_APOSTROPHE;
+	case XK_grave:        return KEY_GRAVE;
+	case XK_Shift_L:      return KEY_LEFTSHIFT;
+	case XK_backslash:    return KEY_BACKSLASH;
+	case XK_z:            return KEY_Z;
+	case XK_x:            return KEY_X;
+	case XK_c:            return KEY_C;
+	case XK_v:            return KEY_V;
+	case XK_b:            return KEY_B;
+	case XK_n:            return KEY_N;
+	case XK_m:            return KEY_M;
+	case XK_comma:        return KEY_COMMA;
+	case XK_period:       return KEY_DOT;
+	case XK_slash:        return KEY_SLASH;
+	case XK_Shift_R:      return KEY_RIGHTSHIFT;
+	case XK_KP_Multiply:  return KEY_KPASTERISK;
+	case XK_Alt_L:        return KEY_LEFTALT;
+	case XK_space:        return KEY_SPACE;
+	case XK_Caps_Lock:    return KEY_CAPSLOCK;
+	case XK_F1:           return KEY_F1;
+	case XK_F2:           return KEY_F2;
+	case XK_F3:           return KEY_F3;
+	case XK_F4:           return KEY_F4;
+	case XK_F5:           return KEY_F5;
+	case XK_F6:           return KEY_F6;
+	case XK_F7:           return KEY_F7;
+	case XK_F8:           return KEY_F8;
+	case XK_F9:           return KEY_F9;
+	case XK_F10:          return KEY_F10;
+	case XK_Num_Lock:     return KEY_NUMLOCK;
+	case XK_Scroll_Lock:  return KEY_SCROLLLOCK;
+	case XK_KP_7:         return KEY_KP7;
+	case XK_KP_8:         return KEY_KP8;
+	case XK_KP_9:         return KEY_KP9;
+	case XK_KP_Subtract:  return KEY_KPMINUS;
+	case XK_KP_4:         return KEY_KP4;
+	case XK_KP_5:         return KEY_KP5;
+	case XK_KP_6:         return KEY_KP6;
+	case XK_KP_Add:       return KEY_KPPLUS;
+	case XK_KP_1:         return KEY_KP1;
+	case XK_KP_2:         return KEY_KP2;
+	case XK_KP_3:         return KEY_KP3;
+	case XK_KP_0:         return KEY_KP0;
+	case XK_KP_Decimal:   return KEY_KPDOT;
+	case XK_F11:          return KEY_F11;
+	case XK_F12:          return KEY_F12;
+	case XK_KP_Enter:     return KEY_KPENTER;
+	case XK_Control_R:    return KEY_RIGHTCTRL;
+	case XK_KP_Divide:    return KEY_KPSLASH;
+	case XK_Print:        return KEY_SYSRQ;
+	case XK_Alt_R:        return KEY_RIGHTALT;
+	case XK_Home:         return KEY_HOME;
+	case XK_Up:           return KEY_UP;
+	case XK_Prior:        return KEY_PAGEUP;
+	case XK_Left:         return KEY_LEFT;
+	case XK_Right:        return KEY_RIGHT;
+	case XK_End:          return KEY_END;
+	case XK_Down:         return KEY_DOWN;
+	case XK_Next:         return KEY_PAGEDOWN;
+	case XK_Insert:       return KEY_INSERT;
+	case XK_Delete:       return KEY_DELETE;
+	case XK_Super_L:      return KEY_LEFTMETA;
+	case XK_Super_R:      return KEY_RIGHTMETA;
+	case XK_Menu:         return KEY_MENU;
+	case XK_A:            return KEY_A;
+	case XK_B:            return KEY_B;
+	case XK_C:            return KEY_C;
+	case XK_D:            return KEY_D;
+	case XK_E:            return KEY_E;
+	case XK_F:            return KEY_F;
+	case XK_G:            return KEY_G;
+	case XK_H:            return KEY_H;
+	case XK_I:            return KEY_I;
+	case XK_J:            return KEY_J;
+	case XK_K:            return KEY_K;
+	case XK_L:            return KEY_L;
+	case XK_M:            return KEY_M;
+	case XK_N:            return KEY_N;
+	case XK_O:            return KEY_O;
+	case XK_P:            return KEY_P;
+	case XK_Q:            return KEY_Q;
+	case XK_R:            return KEY_R;
+	case XK_S:            return KEY_S;
+	case XK_T:            return KEY_T;
+	case XK_U:            return KEY_U;
+	case XK_V:            return KEY_V;
+	case XK_W:            return KEY_W;
+	case XK_X:            return KEY_X;
+	case XK_Y:            return KEY_Y;
+	case XK_Z:            return KEY_Z;
+	default:
+		return -1;
+	}
+}
+
+
+
+
+
+int LinuxKeyboardInput::utf8ToLinuxKeycode( const QByteArray& utf8Data )
+{
+	if( utf8Data.size() != 1 )
+	{
+		return -1;
+	}
+
+	const char c = utf8Data.at( 0 );
+
+	// digit_0 maps to KEY_0, not KEY_1 + (-1)
+	if( c >= '0' && c <= '9' )
+	{
+		constexpr int digitKeycodes[] = { 11, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+		return digitKeycodes[ c - '0' ];
+	}
+
+	// Linux keycodes for letters are NOT sequential (KEY_A=30, KEY_B=48, etc.)
+	// Must use explicit lookup instead of KEY_A + offset
+	constexpr int letterKeycodes[] = {
+		// a b c d e f g h i j k l m n o p q r s t u v w x y z
+		30,48,46,32,18,33,34,35,23,36,37,38,50,49,24,25,16,19,31,20,22,47,17,45,21,44
+		// A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+		// same values as lowercase
+	};
+
+	if( c >= 'a' && c <= 'z' )
+	{
+		return letterKeycodes[ c - 'a' ];
+	}
+	if( c >= 'A' && c <= 'Z' )
+	{
+		return letterKeycodes[ c - 'A' ];
+	}
+	if( c >= '0' && c <= '9' )
+	{
+		return KEY_1 + ( c - '1' );
+	}
+
+	switch( c )
+	{
+	case '!': return KEY_1;
+	case '@': return KEY_2;
+	case '#': return KEY_3;
+	case '$': return KEY_4;
+	case '%': return KEY_5;
+	case '^': return KEY_6;
+	case '&': return KEY_7;
+	case '*': return KEY_8;
+	case '(': return KEY_9;
+	case ')': return KEY_0;
+	case '-': return KEY_MINUS;
+	case '_': return KEY_MINUS;
+	case '=': return KEY_EQUAL;
+	case '+': return KEY_EQUAL;
+	case '[': return KEY_LEFTBRACE;
+	case '{': return KEY_LEFTBRACE;
+	case ']': return KEY_RIGHTBRACE;
+	case '}': return KEY_RIGHTBRACE;
+	case '\\': return KEY_BACKSLASH;
+	case '|': return KEY_BACKSLASH;
+	case ';': return KEY_SEMICOLON;
+	case ':': return KEY_SEMICOLON;
+	case '\'': return KEY_APOSTROPHE;
+	case '"': return KEY_APOSTROPHE;
+	case '`': return KEY_GRAVE;
+	case '~': return KEY_GRAVE;
+	case ',': return KEY_COMMA;
+	case '<': return KEY_COMMA;
+	case '.': return KEY_DOT;
+	case '>': return KEY_DOT;
+	case '/': return KEY_SLASH;
+	case '?': return KEY_SLASH;
+	case ' ': return KEY_SPACE;
+	case '\n': return KEY_ENTER;
+	case '\t': return KEY_TAB;
+	default: return -1;
 	}
 }

--- a/plugins/platform/linux/LinuxKeyboardInput.h
+++ b/plugins/platform/linux/LinuxKeyboardInput.h
@@ -44,7 +44,21 @@ public:
 	void sendString(const QString& string, int keyPressInterval);
 
 private:
-	Display* m_display;
-	FakeKey* m_fakeKeyHandle;
+	// X11/libfakekey path
+	Display* m_display{nullptr};
+	FakeKey* m_fakeKeyHandle{nullptr};
+
+	// Wayland/uinput path
+	int m_uinputFd{-1};
+	bool m_uinputAvailable{false};
+	const bool m_isWaylandSession;
+
+	void initUinput();
+	void cleanupUinput();
+	void pressAndReleaseKeyUinput(uint32_t linuxKeycode);
+	void pressAndReleaseKeyUinputUtf8(const QByteArray& utf8Data);
+
+	static int keysymToLinuxKeycode(uint32_t keysym);
+	static int utf8ToLinuxKeycode(const QByteArray& utf8Data);
 
 };

--- a/plugins/vncserver/headless/CMakeLists.txt
+++ b/plugins/vncserver/headless/CMakeLists.txt
@@ -1,8 +1,15 @@
 include(BuildVeyonPlugin)
 
 get_property(HAVE_LIBVNCCLIENT GLOBAL PROPERTY HAVE_LIBVNCCLIENT)
-if(HAVE_LIBVNCCLIENT)
+if(HAVE_LIBVNCCLIENT OR VEYON_USE_BUILTIN_LIBVNC)
 	find_package(LibVNCServer 0.9.8)
+endif()
+
+if(NOT LibVNCServer_FOUND AND VEYON_USE_BUILTIN_LIBVNC)
+	# When VEYON_USE_BUILTIN_LIBVNC is ON, core uses bundled libvncclient
+	# so HAVE_LIBVNCCLIENT is false and LibVNCServer won't be found.
+	# headless-vnc-server does not have a bundled fallback, so it won't
+	# build when LibVNCServer is not available as a system package.
 endif()
 
 if(LibVNCServer_FOUND)

--- a/plugins/vncserver/pipewire/CMakeLists.txt
+++ b/plugins/vncserver/pipewire/CMakeLists.txt
@@ -8,7 +8,7 @@ if(HAVE_LIBVNCCLIENT)
 	find_package(LibVNCServer 0.9.8)
 endif()
 
-if(NOT LibVNCServer_FOUND)
+if(VEYON_USE_BUILTIN_LIBVNC OR NOT LibVNCServer_FOUND)
 	include(LibVNCServerIntegration)
 
 	set(libvncserver_SOURCES
@@ -42,7 +42,7 @@ if(NOT LibVNCServer_FOUND)
 		${libvncserver_DIR}/src/common/vncauth.c)
 endif()
 
-if(PipeWire_FOUND AND Qt${QT_MAJOR_VERSION}DBus_FOUND AND LibVNCServer_FOUND)
+if(PipeWire_FOUND AND Qt${QT_MAJOR_VERSION}DBus_FOUND AND (LibVNCServer_FOUND OR VEYON_USE_BUILTIN_LIBVNC))
 
 	qt_add_dbus_interface(DBUS_GENERATED_SOURCES
 		dbus/org.freedesktop.portal.RemoteDesktop.xml

--- a/plugins/vncserver/pipewire/CMakeLists.txt
+++ b/plugins/vncserver/pipewire/CMakeLists.txt
@@ -8,6 +8,40 @@ if(HAVE_LIBVNCCLIENT)
 	find_package(LibVNCServer 0.9.8)
 endif()
 
+if(NOT LibVNCServer_FOUND)
+	include(LibVNCServerIntegration)
+
+	set(libvncserver_SOURCES
+		${libvncserver_DIR}/src/libvncserver/auth.c
+		${libvncserver_DIR}/src/libvncserver/cargs.c
+		${libvncserver_DIR}/src/libvncserver/corre.c
+		${libvncserver_DIR}/src/libvncserver/cursor.c
+		${libvncserver_DIR}/src/libvncserver/cutpaste.c
+		${libvncserver_DIR}/src/libvncserver/draw.c
+		${libvncserver_DIR}/src/libvncserver/font.c
+		${libvncserver_DIR}/src/libvncserver/hextile.c
+		${libvncserver_DIR}/src/libvncserver/httpd.c
+		${libvncserver_DIR}/src/libvncserver/main.c
+		${libvncserver_DIR}/src/libvncserver/rfbregion.c
+		${libvncserver_DIR}/src/libvncserver/rfbserver.c
+		${libvncserver_DIR}/src/libvncserver/rre.c
+		${libvncserver_DIR}/src/libvncserver/scale.c
+		${libvncserver_DIR}/src/libvncserver/selbox.c
+		${libvncserver_DIR}/src/libvncserver/sockets.c
+		${libvncserver_DIR}/src/libvncserver/stats.c
+		${libvncserver_DIR}/src/libvncserver/translate.c
+		${libvncserver_DIR}/src/libvncserver/ultra.c
+		${libvncserver_DIR}/src/libvncserver/zlib.c
+		${libvncserver_DIR}/src/libvncserver/zrle.c
+		${libvncserver_DIR}/src/libvncserver/zrleoutstream.c
+		${libvncserver_DIR}/src/libvncserver/zrlepalettehelper.c
+		${libvncserver_DIR}/src/libvncserver/tight.c
+		${libvncserver_DIR}/src/common/d3des.c
+		${libvncserver_DIR}/src/common/sockets.c
+		${libvncserver_DIR}/src/common/turbojpeg.c
+		${libvncserver_DIR}/src/common/vncauth.c)
+endif()
+
 if(PipeWire_FOUND AND Qt${QT_MAJOR_VERSION}DBus_FOUND AND LibVNCServer_FOUND)
 
 	qt_add_dbus_interface(DBUS_GENERATED_SOURCES
@@ -37,16 +71,33 @@ if(PipeWire_FOUND AND Qt${QT_MAJOR_VERSION}DBus_FOUND AND LibVNCServer_FOUND)
 		PortalSession.cpp
 		PortalSession.h
 		${DBUS_GENERATED_SOURCES}
+		${libvncserver_SOURCES}
 	)
 
-	target_link_libraries(pipewire-vnc-server
-		PRIVATE
-			PipeWire::PipeWire
-			Qt${QT_MAJOR_VERSION}::DBus
-			LibVNC::LibVNCServer
+	target_link_libraries(pipewire-vnc-server PRIVATE
+		PipeWire::PipeWire
+		Qt${QT_MAJOR_VERSION}::DBus
 	)
+
+	if(LibVNCServer_FOUND)
+		target_link_libraries(pipewire-vnc-server PRIVATE LibVNC::LibVNCServer)
+	else()
+		target_link_libraries(pipewire-vnc-server PRIVATE
+			Threads::Threads
+			PNG::PNG
+			${ZLIB_LIBRARIES}
+			${JPEG_LIBRARIES}
+			${LZO_LIBRARIES})
+		target_include_directories(pipewire-vnc-server PRIVATE
+			${libvncserver_DIR}/libvncserver
+			${libvncserver_DIR}/common)
+	endif()
 
 	target_compile_options(pipewire-vnc-server PRIVATE -Wno-parentheses)
+
+	set_source_files_properties(${libvncserver_SOURCES} PROPERTIES
+		COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-unused-function -Wno-unused-variable"
+		SKIP_PRECOMPILE_HEADERS TRUE)
 
 	install(
 		PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/veyon-preauth-kde.sh"

--- a/plugins/vncserver/pipewire/PipeWireVncServer.h
+++ b/plugins/vncserver/pipewire/PipeWireVncServer.h
@@ -90,7 +90,7 @@ public:
 
 	Plugin::Flags flags() const override
 	{
-		return Plugin::NoFlags;
+		return Plugin::ProvidesDefaultImplementation;
 	}
 
 	QStringList supportedSessionTypes() const override

--- a/plugins/vncserver/pipewire/PortalSession.cpp
+++ b/plugins/vncserver/pipewire/PortalSession.cpp
@@ -23,12 +23,15 @@
  */
 
 #include <linux/input.h>
+#include <unistd.h>
 
 #include <QDBusArgument>
 #include <QDBusObjectPath>
 #include <QDBusPendingCallWatcher>
 #include <QDBusPendingReply>
 #include <QDBusUnixFileDescriptor>
+#include <QGuiApplication>
+#include <QProcess>
 #include <QRandomGenerator>
 
 #include "PortalSession.h"
@@ -37,14 +40,21 @@
 // XDG Desktop Portal service and interface names
 static const auto PortalService = QStringLiteral("org.freedesktop.portal.Desktop");
 static const auto PortalObjectPath = QStringLiteral("/org/freedesktop/portal/desktop");
-static const auto ConnectionName = QStringLiteral("PipeWirePortalSession");
-
 PortalSession::PortalSession(QObject* parent)
 	: QObject(parent)
-	, m_sessionBus(QDBusConnection::connectToBus(QDBusConnection::SessionBus, ConnectionName))
+	, m_sessionBus(QDBusConnection::sessionBus())
 {
 	const auto appId = QGuiApplication::desktopFileName();
 
+	// Use the default session bus connection so the portal can properly
+	// identify this application by its well-known bus name and match
+	// pre-authorized permissions. Creating a separate connection would
+	// cause the portal to see a numeric :1.xx ID instead of the app ID,
+	// which breaks pre-authorization via flatpak permission-set.
+
+	// Apply KDE pre-authorization so the consent dialog can be suppressed
+	// in unattended/kiosk scenarios. These calls are best-effort and may
+	// fail silently if flatpak is not installed.
 	QProcess::execute(QStringLiteral("flatpak"),
 					  {QStringLiteral("permission-set"), QStringLiteral("kde-authorized"),
 					   QStringLiteral("screencast"), appId, QStringLiteral("yes")});
@@ -52,10 +62,13 @@ PortalSession::PortalSession(QObject* parent)
 					  {QStringLiteral("permission-set"), QStringLiteral("kde-authorized"),
 					   QStringLiteral("remote-desktop"), appId, QStringLiteral("yes")});
 
+	// Register the well-known name so the portal can resolve our app ID.
+	// This is not strictly required when using the default session bus,
+	// but helps consistency for logging and debugging.
 	if (!m_sessionBus.registerService(appId))
 	{
-		vWarning() << "Could not register D-Bus service name" << appId
-				   << ":" << m_sessionBus.lastError().message();
+		vDebug() << "Could not register D-Bus service name" << appId
+				 << ":" << m_sessionBus.lastError().message();
 	}
 
 	m_remoteDesktop = new OrgFreedesktopPortalRemoteDesktopInterface(PortalService, PortalObjectPath, m_sessionBus, this);
@@ -68,7 +81,6 @@ PortalSession::~PortalSession()
 {
 	close();
 	m_sessionBus.unregisterService(QGuiApplication::desktopFileName());
-	m_sessionBus.disconnectFromBus(ConnectionName);
 }
 
 

--- a/plugins/vncserver/pipewire/PortalSession.h
+++ b/plugins/vncserver/pipewire/PortalSession.h
@@ -44,9 +44,9 @@
  * All portal responses arrive asynchronously via the /org/freedesktop/portal/desktop/response
  * signal and are dispatched to the appropriate handler.
  *
- * The app_id used for permission-store lookups is "io.veyon.Veyon.Server".
+ * The app_id used for permission-store lookups is "io.veyon.veyon-server".
  * KDE Plasma admins can pre-authorize unattended access via:
- *   flatpak permission-set kde-authorized screencast io.veyon.Veyon.Server yes
+ *   flatpak permission-set kde-authorized screencast io.veyon.veyon-server yes
  * or directly through the DBus PermissionStore interface.
  */
 class PortalSession : public QObject

--- a/plugins/vncserver/pipewire/README.md
+++ b/plugins/vncserver/pipewire/README.md
@@ -37,7 +37,7 @@ restarted after a short delay.
 The plugin registers itself under the stable application identifier:
 
 ```
-io.veyon.Veyon.Server
+io.veyon.veyon-server
 ```
 
 This identifier is used by the XDG Desktop Portal permission store.
@@ -47,15 +47,15 @@ an administrator survive service restarts.
 The identifier is registered in three complementary ways:
 
 1. **D-Bus well-known name** — `PortalSession` calls
-   `QDBusConnection::sessionBus().registerService("io.veyon.Veyon.Server")`
+   `QDBusConnection::sessionBus().registerService("io.veyon.veyon-server")`
    at start-up so the portal sees the correct app_id for every method call.
 
-2. **XDG `.desktop` file** — `io.veyon.Veyon.Server.desktop` is installed to
+2. **XDG `.desktop` file** — `io.veyon.veyon-server.desktop` is installed to
    `/usr/share/applications/`.  The portal reads `Name=Veyon Server` from it
    to display "Veyon Server" (instead of the terminal emulator or process name)
    in the KDE permission dialog.
 
-3. **D-Bus session service file** — `io.veyon.Veyon.Server.service` is
+3. **D-Bus session service file** — `io.veyon.veyon-server.service` is
    installed to `/usr/share/dbus-1/services/`.  It maps the well-known bus name
    to the `veyon-server` executable so dbus-daemon and xdg-desktop-portal can
    follow the full `bus_name → desktop_file → display_name` chain.
@@ -73,7 +73,7 @@ store table `kde-authorized`.
 ### Method 1: `flatpak permission-set` (recommended)
 
 ```bash
-flatpak permission-set kde-authorized screencast io.veyon.Veyon.Server yes
+flatpak permission-set kde-authorized screencast io.veyon.veyon-server yes
 ```
 
 This command must be run **as the target user** (the user whose desktop is to
@@ -93,7 +93,7 @@ dbus-send \
   string:kde-authorized \
   boolean:false \
   string:screencast \
-  string:io.veyon.Veyon.Server \
+  string:io.veyon.veyon-server \
   array:string:yes
 ```
 

--- a/plugins/vncserver/pipewire/veyon-preauth-kde.sh
+++ b/plugins/vncserver/pipewire/veyon-preauth-kde.sh
@@ -20,16 +20,16 @@
 #   - Either 'flatpak' CLI or direct DBus access to the PermissionStore
 #
 # What this script does:
-#   Grants "io.veyon.Veyon.Server" permanent permission for RemoteDesktop portal
+#   Grants "io.veyon.veyon-server" permanent permission for RemoteDesktop portal
 #   access under KDE.  After running this script the Veyon Server daemon will be
 #   able to capture the screen and receive input without any interactive portal
 #   consent dialog.
 #
-# Stable app_id used: io.veyon.Veyon.Server
+# Stable app_id used: io.veyon.veyon-server
 # Permission table  : kde-authorized
 # Permission type   : screencast
 
-APP_ID="io.veyon.Veyon.Server"
+APP_ID="io.veyon.veyon-server"
 TABLE="kde-authorized"
 # KDE Plasma's PermissionStore uses "screencast" (not "remote-desktop") as the
 # permission ID for the kde-authorized screen-capture pre-authorization table.

--- a/plugins/vncserver/x11vnc-builtin/CMakeLists.txt
+++ b/plugins/vncserver/x11vnc-builtin/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT VEYON_X11VNC_EXTERNAL)
 		message(WARNING "No suitable LibVNCClient library found therefore performing internal build of LibVNCServer as well to avoid binary compatibility issues")
 	endif()
 
-	if(NOT LibVNCServer_FOUND)
+	if(VEYON_USE_BUILTIN_LIBVNC OR NOT LibVNCServer_FOUND)
 		include(LibVNCServerIntegration)
 	endif()
 
@@ -118,7 +118,7 @@ if(NOT VEYON_X11VNC_EXTERNAL)
 
 	set(X11VNC_CONFIG ${CMAKE_BINARY_DIR}/config.h)
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h @ONLY)
-	if(NOT LibVNCServer_FOUND)
+	if(VEYON_USE_BUILTIN_LIBVNC OR NOT LibVNCServer_FOUND)
 		set(libvncserver_SOURCES
 			${libvncserver_DIR}/src/libvncserver/auth.c
 			${libvncserver_DIR}/src/libvncserver/cargs.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
 if(WITH_FUZZERS)
 	add_subdirectory(libfuzzer)
 endif()
+
+add_subdirectory(unit)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,0 +1,47 @@
+if(WITH_TESTS AND VEYON_BUILD_LINUX)
+
+	find_package(X11 REQUIRED)
+
+	#
+	# LinuxKeyboardMappingTest: tests keysym → linux keycode mapping tables
+	# and UTF-8 → linux keycode conversion.
+	#
+	add_executable(LinuxKeyboardMappingTest
+		LinuxKeyboardMappingTest.cpp
+		${CMAKE_SOURCE_DIR}/plugins/platform/linux/LinuxKeyboardInput.cpp
+		${CMAKE_SOURCE_DIR}/3rdparty/libfakekey/src/libfakekey.c
+	)
+
+	target_include_directories(LinuxKeyboardMappingTest PRIVATE
+		${CMAKE_SOURCE_DIR}/plugins/platform/linux
+		${CMAKE_SOURCE_DIR}/3rdparty/libfakekey
+		${CMAKE_SOURCE_DIR}/core/src
+		${CMAKE_SOURCE_DIR}/core/src/Configuration
+	)
+
+	target_link_libraries(LinuxKeyboardMappingTest PRIVATE
+		Qt${QT_MAJOR_VERSION}::Test
+		Qt${QT_MAJOR_VERSION}::Core
+		veyon-core
+		${X11_LIBRARIES}
+		${X11_XTest_LIB}
+	)
+
+	add_test(NAME LinuxKeyboardMappingTest COMMAND LinuxKeyboardMappingTest)
+
+	#
+	# PipeWireVncServerTest: tests BGRx→RGB conversion, damage rect clamping,
+	# and portal session token/path generation.
+	#
+	add_executable(PipeWireVncServerTest
+		PipeWireVncServerTest.cpp
+	)
+
+	target_link_libraries(PipeWireVncServerTest PRIVATE
+		Qt${QT_MAJOR_VERSION}::Test
+		Qt${QT_MAJOR_VERSION}::Core
+	)
+
+	add_test(NAME PipeWireVncServerTest COMMAND PipeWireVncServerTest)
+
+endif()

--- a/tests/unit/LinuxKeyboardMappingTest.cpp
+++ b/tests/unit/LinuxKeyboardMappingTest.cpp
@@ -1,0 +1,355 @@
+/*
+ * LinuxKeyboardMappingTest.cpp - test keysym/UTF-8 to Linux keycode mapping
+ *
+ * Copyright (c) 2019-2026 Tobias Junghans <tobydox@veyon.io>
+ *
+ * This file is part of Veyon - https://veyon.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+#include <QObject>
+#include <QTest>
+
+// include linux input constants for KEY_MENU etc.
+#include <linux/input.h>
+
+
+#define private public
+#include "LinuxKeyboardInput.h"
+#undef private
+
+class LinuxKeyboardMappingTest : public QObject
+{
+	Q_OBJECT
+
+private Q_SLOTS:
+	void testKeysymToLinuxKeycode_data();
+	void testKeysymToLinuxKeycode();
+	void testUtf8ToLinuxKeycode_data();
+	void testUtf8ToLinuxKeycode();
+	void testUnmappedKeysymReturnsMinusOne();
+	void testUnmappedUtf8ReturnsMinusOne();
+};
+
+void LinuxKeyboardMappingTest::testKeysymToLinuxKeycode_data()
+{
+	QTest::addColumn<quint32>("keysym");
+	QTest::addColumn<int>("expectedKeycode");
+
+	// a-z
+	QTest::addRow("a") << quint32(0x0061) << 30;
+	QTest::addRow("b") << quint32(0x0062) << 48;
+	QTest::addRow("c") << quint32(0x0063) << 46;
+	QTest::addRow("d") << quint32(0x0064) << 32;
+	QTest::addRow("e") << quint32(0x0065) << 18;
+	QTest::addRow("f") << quint32(0x0066) << 33;
+	QTest::addRow("g") << quint32(0x0067) << 34;
+	QTest::addRow("h") << quint32(0x0068) << 35;
+	QTest::addRow("i") << quint32(0x0069) << 23;
+	QTest::addRow("j") << quint32(0x006a) << 36;
+	QTest::addRow("k") << quint32(0x006b) << 37;
+	QTest::addRow("l") << quint32(0x006c) << 38;
+	QTest::addRow("m") << quint32(0x006d) << 50;
+	QTest::addRow("n") << quint32(0x006e) << 49;
+	QTest::addRow("o") << quint32(0x006f) << 24;
+	QTest::addRow("p") << quint32(0x0070) << 25;
+	QTest::addRow("q") << quint32(0x0071) << 16;
+	QTest::addRow("r") << quint32(0x0072) << 19;
+	QTest::addRow("s") << quint32(0x0073) << 31;
+	QTest::addRow("t") << quint32(0x0074) << 20;
+	QTest::addRow("u") << quint32(0x0075) << 22;
+	QTest::addRow("v") << quint32(0x0076) << 47;
+	QTest::addRow("w") << quint32(0x0077) << 17;
+	QTest::addRow("x") << quint32(0x0078) << 45;
+	QTest::addRow("y") << quint32(0x0079) << 21;
+	QTest::addRow("z") << quint32(0x007a) << 44;
+
+	// A-Z
+	QTest::addRow("A") << quint32(0x0041) << 30;
+	QTest::addRow("B") << quint32(0x0042) << 48;
+	QTest::addRow("C") << quint32(0x0043) << 46;
+	QTest::addRow("D") << quint32(0x0044) << 32;
+	QTest::addRow("E") << quint32(0x0045) << 18;
+	QTest::addRow("F") << quint32(0x0046) << 33;
+	QTest::addRow("G") << quint32(0x0047) << 34;
+	QTest::addRow("H") << quint32(0x0048) << 35;
+	QTest::addRow("I") << quint32(0x0049) << 23;
+	QTest::addRow("J") << quint32(0x004a) << 36;
+	QTest::addRow("K") << quint32(0x004b) << 37;
+	QTest::addRow("L") << quint32(0x004c) << 38;
+	QTest::addRow("M") << quint32(0x004d) << 50;
+	QTest::addRow("N") << quint32(0x004e) << 49;
+	QTest::addRow("O") << quint32(0x004f) << 24;
+	QTest::addRow("P") << quint32(0x0050) << 25;
+	QTest::addRow("Q") << quint32(0x0051) << 16;
+	QTest::addRow("R") << quint32(0x0052) << 19;
+	QTest::addRow("S") << quint32(0x0053) << 31;
+	QTest::addRow("T") << quint32(0x0054) << 20;
+	QTest::addRow("U") << quint32(0x0055) << 22;
+	QTest::addRow("V") << quint32(0x0056) << 47;
+	QTest::addRow("W") << quint32(0x0057) << 17;
+	QTest::addRow("X") << quint32(0x0058) << 45;
+	QTest::addRow("Y") << quint32(0x0059) << 21;
+	QTest::addRow("Z") << quint32(0x005a) << 44;
+
+	// Digits 0-9
+	QTest::addRow("digit_0") << quint32(0x0030) << 11;
+	QTest::addRow("digit_1") << quint32(0x0031) << 2;
+	QTest::addRow("digit_2") << quint32(0x0032) << 3;
+	QTest::addRow("digit_3") << quint32(0x0033) << 4;
+	QTest::addRow("digit_4") << quint32(0x0034) << 5;
+	QTest::addRow("digit_5") << quint32(0x0035) << 6;
+	QTest::addRow("digit_6") << quint32(0x0036) << 7;
+	QTest::addRow("digit_7") << quint32(0x0037) << 8;
+	QTest::addRow("digit_8") << quint32(0x0038) << 9;
+	QTest::addRow("digit_9") << quint32(0x0039) << 10;
+
+	// Punctuation and symbols
+	QTest::addRow("Minus") << quint32(0x002d) << 12;
+	QTest::addRow("Equal") << quint32(0x003d) << 13;
+	QTest::addRow("BracketLeft") << quint32(0x005b) << 26;
+	QTest::addRow("BracketRight") << quint32(0x005d) << 27;
+	QTest::addRow("Semicolon") << quint32(0x003b) << 39;
+	QTest::addRow("Apostrophe") << quint32(0x0027) << 40;
+	QTest::addRow("Grave") << quint32(0x0060) << 41;
+	QTest::addRow("Backslash") << quint32(0x005c) << 43;
+	QTest::addRow("Comma") << quint32(0x002c) << 51;
+	QTest::addRow("Period") << quint32(0x002e) << 52;
+	QTest::addRow("Slash") << quint32(0x002f) << 53;
+
+	// Modifier keys
+	QTest::addRow("Shift_L") << quint32(0xffe1) << 42;
+	QTest::addRow("Shift_R") << quint32(0xffe2) << 54;
+	QTest::addRow("Control_L") << quint32(0xffe3) << 29;
+	QTest::addRow("Control_R") << quint32(0xffe4) << 97;
+	QTest::addRow("Alt_L") << quint32(0xffe9) << 56;
+	QTest::addRow("Alt_R") << quint32(0xffea) << 100;
+	QTest::addRow("Super_L") << quint32(0xffeb) << 125;
+	QTest::addRow("Super_R") << quint32(0xffec) << 126;
+	QTest::addRow("Menu") << quint32(0xff67) << KEY_MENU;
+
+	// Whitespace and editing keys
+	QTest::addRow("Space") << quint32(0x0020) << 57;
+	QTest::addRow("Return") << quint32(0xff0d) << 28;
+	QTest::addRow("Tab") << quint32(0xff09) << 15;
+	QTest::addRow("BackSpace") << quint32(0xff08) << 14;
+	QTest::addRow("Escape") << quint32(0xff1b) << 1;
+
+	// Navigation keys
+	QTest::addRow("Home") << quint32(0xff50) << 102;
+	QTest::addRow("Up") << quint32(0xff52) << 103;
+	QTest::addRow("Prior") << quint32(0xff55) << 104;
+	QTest::addRow("Left") << quint32(0xff51) << 105;
+	QTest::addRow("Right") << quint32(0xff53) << 106;
+	QTest::addRow("End") << quint32(0xff57) << 107;
+	QTest::addRow("Down") << quint32(0xff54) << 108;
+	QTest::addRow("Next") << quint32(0xff56) << 109;
+	QTest::addRow("Insert") << quint32(0xff63) << 110;
+	QTest::addRow("Delete") << quint32(0xffff) << 111;
+
+	// Function keys
+	QTest::addRow("F1") << quint32(0xffbe) << 59;
+	QTest::addRow("F2") << quint32(0xffbf) << 60;
+	QTest::addRow("F3") << quint32(0xffc0) << 61;
+	QTest::addRow("F4") << quint32(0xffc1) << 62;
+	QTest::addRow("F5") << quint32(0xffc2) << 63;
+	QTest::addRow("F6") << quint32(0xffc3) << 64;
+	QTest::addRow("F7") << quint32(0xffc4) << 65;
+	QTest::addRow("F8") << quint32(0xffc5) << 66;
+	QTest::addRow("F9") << quint32(0xffc6) << 67;
+	QTest::addRow("F10") << quint32(0xffc7) << 68;
+	QTest::addRow("F11") << quint32(0xffc8) << 87;
+	QTest::addRow("F12") << quint32(0xffc9) << 88;
+
+	// Lock keys
+	QTest::addRow("Caps_Lock") << quint32(0xffe5) << 58;
+	QTest::addRow("Num_Lock") << quint32(0xff7f) << 69;
+	QTest::addRow("Scroll_Lock") << quint32(0xff14) << 70;
+	QTest::addRow("Print") << quint32(0xff61) << 99;
+
+	// Keypad keys
+	QTest::addRow("KP_Multiply") << quint32(0xffaa) << 55;
+	QTest::addRow("KP_7") << quint32(0xffb7) << 71;
+	QTest::addRow("KP_8") << quint32(0xffb8) << 72;
+	QTest::addRow("KP_9") << quint32(0xffb9) << 73;
+	QTest::addRow("KP_Subtract") << quint32(0xffad) << 74;
+	QTest::addRow("KP_4") << quint32(0xffb4) << 75;
+	QTest::addRow("KP_5") << quint32(0xffb5) << 76;
+	QTest::addRow("KP_6") << quint32(0xffb6) << 77;
+	QTest::addRow("KP_Add") << quint32(0xffab) << 78;
+	QTest::addRow("KP_1") << quint32(0xffb1) << 79;
+	QTest::addRow("KP_2") << quint32(0xffb2) << 80;
+	QTest::addRow("KP_3") << quint32(0xffb3) << 81;
+	QTest::addRow("KP_0") << quint32(0xffb0) << 82;
+	QTest::addRow("KP_Decimal") << quint32(0xffae) << 83;
+	QTest::addRow("KP_Enter") << quint32(0xff8d) << 96;
+	QTest::addRow("KP_Divide") << quint32(0xffaf) << 98;
+}
+
+void LinuxKeyboardMappingTest::testKeysymToLinuxKeycode()
+{
+	QFETCH(quint32, keysym);
+	QFETCH(int, expectedKeycode);
+
+	QCOMPARE(LinuxKeyboardInput::keysymToLinuxKeycode(keysym), expectedKeycode);
+}
+
+void LinuxKeyboardMappingTest::testUtf8ToLinuxKeycode_data()
+{
+	QTest::addColumn<QByteArray>("utf8");
+	QTest::addColumn<int>("expectedKeycode");
+
+	// a-z
+	QTest::addRow("a") << QByteArrayLiteral("a") << 30;
+	QTest::addRow("b") << QByteArrayLiteral("b") << 48;
+	QTest::addRow("c") << QByteArrayLiteral("c") << 46;
+	QTest::addRow("d") << QByteArrayLiteral("d") << 32;
+	QTest::addRow("e") << QByteArrayLiteral("e") << 18;
+	QTest::addRow("f") << QByteArrayLiteral("f") << 33;
+	QTest::addRow("g") << QByteArrayLiteral("g") << 34;
+	QTest::addRow("h") << QByteArrayLiteral("h") << 35;
+	QTest::addRow("i") << QByteArrayLiteral("i") << 23;
+	QTest::addRow("j") << QByteArrayLiteral("j") << 36;
+	QTest::addRow("k") << QByteArrayLiteral("k") << 37;
+	QTest::addRow("l") << QByteArrayLiteral("l") << 38;
+	QTest::addRow("m") << QByteArrayLiteral("m") << 50;
+	QTest::addRow("n") << QByteArrayLiteral("n") << 49;
+	QTest::addRow("o") << QByteArrayLiteral("o") << 24;
+	QTest::addRow("p") << QByteArrayLiteral("p") << 25;
+	QTest::addRow("q") << QByteArrayLiteral("q") << 16;
+	QTest::addRow("r") << QByteArrayLiteral("r") << 19;
+	QTest::addRow("s") << QByteArrayLiteral("s") << 31;
+	QTest::addRow("t") << QByteArrayLiteral("t") << 20;
+	QTest::addRow("u") << QByteArrayLiteral("u") << 22;
+	QTest::addRow("v") << QByteArrayLiteral("v") << 47;
+	QTest::addRow("w") << QByteArrayLiteral("w") << 17;
+	QTest::addRow("x") << QByteArrayLiteral("x") << 45;
+	QTest::addRow("y") << QByteArrayLiteral("y") << 21;
+	QTest::addRow("z") << QByteArrayLiteral("z") << 44;
+
+	// A-Z
+	QTest::addRow("A") << QByteArrayLiteral("A") << 30;
+	QTest::addRow("B") << QByteArrayLiteral("B") << 48;
+	QTest::addRow("C") << QByteArrayLiteral("C") << 46;
+	QTest::addRow("D") << QByteArrayLiteral("D") << 32;
+	QTest::addRow("E") << QByteArrayLiteral("E") << 18;
+	QTest::addRow("F") << QByteArrayLiteral("F") << 33;
+	QTest::addRow("G") << QByteArrayLiteral("G") << 34;
+	QTest::addRow("H") << QByteArrayLiteral("H") << 35;
+	QTest::addRow("I") << QByteArrayLiteral("I") << 23;
+	QTest::addRow("J") << QByteArrayLiteral("J") << 36;
+	QTest::addRow("K") << QByteArrayLiteral("K") << 37;
+	QTest::addRow("L") << QByteArrayLiteral("L") << 38;
+	QTest::addRow("M") << QByteArrayLiteral("M") << 50;
+	QTest::addRow("N") << QByteArrayLiteral("N") << 49;
+	QTest::addRow("O") << QByteArrayLiteral("O") << 24;
+	QTest::addRow("P") << QByteArrayLiteral("P") << 25;
+	QTest::addRow("Q") << QByteArrayLiteral("Q") << 16;
+	QTest::addRow("R") << QByteArrayLiteral("R") << 19;
+	QTest::addRow("S") << QByteArrayLiteral("S") << 31;
+	QTest::addRow("T") << QByteArrayLiteral("T") << 20;
+	QTest::addRow("U") << QByteArrayLiteral("U") << 22;
+	QTest::addRow("V") << QByteArrayLiteral("V") << 47;
+	QTest::addRow("W") << QByteArrayLiteral("W") << 17;
+	QTest::addRow("X") << QByteArrayLiteral("X") << 45;
+	QTest::addRow("Y") << QByteArrayLiteral("Y") << 21;
+	QTest::addRow("Z") << QByteArrayLiteral("Z") << 44;
+
+	// Digits
+	QTest::addRow("digit_0") << QByteArrayLiteral("0") << 11;
+	QTest::addRow("digit_1") << QByteArrayLiteral("1") << 2;
+	QTest::addRow("digit_2") << QByteArrayLiteral("2") << 3;
+	QTest::addRow("digit_3") << QByteArrayLiteral("3") << 4;
+	QTest::addRow("digit_4") << QByteArrayLiteral("4") << 5;
+	QTest::addRow("digit_5") << QByteArrayLiteral("5") << 6;
+	QTest::addRow("digit_6") << QByteArrayLiteral("6") << 7;
+	QTest::addRow("digit_7") << QByteArrayLiteral("7") << 8;
+	QTest::addRow("digit_8") << QByteArrayLiteral("8") << 9;
+	QTest::addRow("digit_9") << QByteArrayLiteral("9") << 10;
+
+	// Shifted digits
+	QTest::addRow("exclam") << QByteArrayLiteral("!") << 2;
+	QTest::addRow("at") << QByteArrayLiteral("@") << 3;
+	QTest::addRow("numbersign") << QByteArrayLiteral("#") << 4;
+	QTest::addRow("dollar") << QByteArrayLiteral("$") << 5;
+	QTest::addRow("percent") << QByteArrayLiteral("%") << 6;
+	QTest::addRow("asciicircum") << QByteArrayLiteral("^") << 7;
+	QTest::addRow("ampersand") << QByteArrayLiteral("&") << 8;
+	QTest::addRow("asterisk") << QByteArrayLiteral("*") << 9;
+	QTest::addRow("parenleft") << QByteArrayLiteral("(") << 10;
+	QTest::addRow("parenright") << QByteArrayLiteral(")") << 11;
+
+	// Minus/underscore and equal/plus
+	QTest::addRow("minus") << QByteArrayLiteral("-") << 12;
+	QTest::addRow("underscore") << QByteArrayLiteral("_") << 12;
+	QTest::addRow("equal") << QByteArrayLiteral("=") << 13;
+	QTest::addRow("plus") << QByteArrayLiteral("+") << 13;
+
+	// Brackets
+	QTest::addRow("bracketleft") << QByteArrayLiteral("[") << 26;
+	QTest::addRow("braceleft") << QByteArrayLiteral("{") << 26;
+	QTest::addRow("bracketright") << QByteArrayLiteral("]") << 27;
+	QTest::addRow("braceright") << QByteArrayLiteral("}") << 27;
+
+	// Semicolon/colon and apostrophe/quote
+	QTest::addRow("semicolon") << QByteArrayLiteral(";") << 39;
+	QTest::addRow("colon") << QByteArrayLiteral(":") << 39;
+	QTest::addRow("apostrophe") << QByteArrayLiteral("'") << 40;
+	QTest::addRow("quotedbl") << QByteArrayLiteral("\"") << 40;
+
+	// Grave/tilde and backslash/bar
+	QTest::addRow("grave") << QByteArrayLiteral("`") << 41;
+	QTest::addRow("asciitilde") << QByteArrayLiteral("~") << 41;
+	QTest::addRow("backslash") << QByteArrayLiteral("\\") << 43;
+	QTest::addRow("bar") << QByteArrayLiteral("|") << 43;
+
+	// Comma/less, period/greater, slash/question
+	QTest::addRow("comma") << QByteArrayLiteral(",") << 51;
+	QTest::addRow("less") << QByteArrayLiteral("<") << 51;
+	QTest::addRow("period") << QByteArrayLiteral(".") << 52;
+	QTest::addRow("greater") << QByteArrayLiteral(">") << 52;
+	QTest::addRow("slash") << QByteArrayLiteral("/") << 53;
+	QTest::addRow("question") << QByteArrayLiteral("?") << 53;
+
+	// Whitespace
+	QTest::addRow("space") << QByteArrayLiteral(" ") << 57;
+	QTest::addRow("newline") << QByteArrayLiteral("\n") << 28;
+	QTest::addRow("tab") << QByteArrayLiteral("\t") << 15;
+}
+
+void LinuxKeyboardMappingTest::testUtf8ToLinuxKeycode()
+{
+	QFETCH(QByteArray, utf8);
+	QFETCH(int, expectedKeycode);
+
+	QCOMPARE(LinuxKeyboardInput::utf8ToLinuxKeycode(utf8), expectedKeycode);
+}
+
+void LinuxKeyboardMappingTest::testUnmappedKeysymReturnsMinusOne()
+{
+	QCOMPARE(LinuxKeyboardInput::keysymToLinuxKeycode(0xdeadbeef), -1);
+}
+
+void LinuxKeyboardMappingTest::testUnmappedUtf8ReturnsMinusOne()
+{
+	QCOMPARE(LinuxKeyboardInput::utf8ToLinuxKeycode(QByteArrayLiteral("\xc3\xa9")), -1);
+}
+
+QTEST_MAIN(LinuxKeyboardMappingTest)
+
+#include "LinuxKeyboardMappingTest.moc"

--- a/tests/unit/PipeWireVncServerTest.cpp
+++ b/tests/unit/PipeWireVncServerTest.cpp
@@ -1,0 +1,212 @@
+// GPLv2 copyright header (2019-2026 Tobias Junghans)
+#include <QObject>
+#include <QTest>
+#include <QString>
+#include <cstdint>
+
+class PipeWireVncServerTest : public QObject
+{
+    Q_OBJECT
+private Q_SLOTS:
+    void testBgrxToRgbConversion();
+    void testDamageRectClamping();
+    void testPortalTokenPattern();
+    void testPortalRequestPath();
+};
+
+static void convertLineBGRxToRgb(const uint8_t* src, int width, uint8_t* dst)
+{
+    for (int x = 0; x < width; ++x) {
+        const int i = x * 4;
+        dst[i + 0] = src[i + 2]; // R = B
+        dst[i + 1] = src[i + 1]; // G = G
+        dst[i + 2] = src[i + 0]; // B = R
+        dst[i + 3] = src[i + 3]; // A = A
+    }
+}
+
+void PipeWireVncServerTest::testBgrxToRgbConversion()
+{
+    // Test single pixel: pure red BGRx (0x00,0x00,0xFF,0xFF) -> RGBA (0xFF,0x00,0x00,0xFF)
+    {
+        uint8_t src[4] = { 0x00, 0x00, 0xFF, 0xFF };
+        uint8_t dst[4] = { 0 };
+        convertLineBGRxToRgb(src, 1, dst);
+        QCOMPARE(dst[0], uint8_t(0xFF));
+        QCOMPARE(dst[1], uint8_t(0x00));
+        QCOMPARE(dst[2], uint8_t(0x00));
+        QCOMPARE(dst[3], uint8_t(0xFF));
+    }
+
+    // Test single pixel: pure green (0x00,0xFF,0x00,0xFF) -> unchanged
+    {
+        uint8_t src[4] = { 0x00, 0xFF, 0x00, 0xFF };
+        uint8_t dst[4] = { 0 };
+        convertLineBGRxToRgb(src, 1, dst);
+        QCOMPARE(dst[0], uint8_t(0x00));
+        QCOMPARE(dst[1], uint8_t(0xFF));
+        QCOMPARE(dst[2], uint8_t(0x00));
+        QCOMPARE(dst[3], uint8_t(0xFF));
+    }
+
+    // Test single pixel: pure blue (0xFF,0x00,0x00,0xFF) -> (0x00,0x00,0xFF,0xFF)
+    {
+        uint8_t src[4] = { 0xFF, 0x00, 0x00, 0xFF };
+        uint8_t dst[4] = { 0 };
+        convertLineBGRxToRgb(src, 1, dst);
+        QCOMPARE(dst[0], uint8_t(0x00));
+        QCOMPARE(dst[1], uint8_t(0x00));
+        QCOMPARE(dst[2], uint8_t(0xFF));
+        QCOMPARE(dst[3], uint8_t(0xFF));
+    }
+
+    // Test multiple pixels with known pattern
+    {
+        // 3 pixels: red, green, blue in BGRx
+        uint8_t src[12] = {
+            0x00, 0x00, 0xFF, 0xFF,  // red in BGRx
+            0x00, 0xFF, 0x00, 0xFF,  // green in BGRx
+            0xFF, 0x00, 0x00, 0xFF   // blue in BGRx
+        };
+        uint8_t dst[12] = { 0 };
+        convertLineBGRxToRgb(src, 3, dst);
+
+        // Pixel 0: should be RGBA red
+        QCOMPARE(dst[0], uint8_t(0xFF));
+        QCOMPARE(dst[1], uint8_t(0x00));
+        QCOMPARE(dst[2], uint8_t(0x00));
+        QCOMPARE(dst[3], uint8_t(0xFF));
+
+        // Pixel 1: should be RGBA green (unchanged)
+        QCOMPARE(dst[4], uint8_t(0x00));
+        QCOMPARE(dst[5], uint8_t(0xFF));
+        QCOMPARE(dst[6], uint8_t(0x00));
+        QCOMPARE(dst[7], uint8_t(0xFF));
+
+        // Pixel 2: should be RGBA blue
+        QCOMPARE(dst[8], uint8_t(0x00));
+        QCOMPARE(dst[9], uint8_t(0x00));
+        QCOMPARE(dst[10], uint8_t(0xFF));
+        QCOMPARE(dst[11], uint8_t(0xFF));
+    }
+
+    // Verify each pixel's 4 bytes are correctly transformed: mixed pattern
+    {
+        // 2 pixels with arbitrary values
+        uint8_t src[8] = {
+            0x10, 0x20, 0x30, 0x40,  // pixel 0
+            0x50, 0x60, 0x70, 0x80   // pixel 1
+        };
+        uint8_t dst[8] = { 0 };
+        convertLineBGRxToRgb(src, 2, dst);
+
+        // Pixel 0: src[B]=0x30 -> dst[R]=0x30, src[G]=0x20 -> dst[G]=0x20, src[R]=0x10 -> dst[B]=0x10, src[A]=0x40 -> dst[A]=0x40
+        QCOMPARE(dst[0], uint8_t(0x30));
+        QCOMPARE(dst[1], uint8_t(0x20));
+        QCOMPARE(dst[2], uint8_t(0x10));
+        QCOMPARE(dst[3], uint8_t(0x40));
+
+        // Pixel 1: src[B]=0x70 -> dst[R]=0x70, src[G]=0x60 -> dst[G]=0x60, src[R]=0x50 -> dst[B]=0x50, src[A]=0x80 -> dst[A]=0x80
+        QCOMPARE(dst[4], uint8_t(0x70));
+        QCOMPARE(dst[5], uint8_t(0x60));
+        QCOMPARE(dst[6], uint8_t(0x50));
+        QCOMPARE(dst[7], uint8_t(0x80));
+    }
+}
+
+void PipeWireVncServerTest::testDamageRectClamping()
+{
+    const int width = 1920;
+    const int height = 1080;
+
+    // Region fully inside: (10,10,100,100) -> clamped to (10,10,110,110)
+    {
+        int x = 10, y = 10, w = 100, h = 100;
+        const int x1 = qBound(0, x, width);
+        const int y1 = qBound(0, y, height);
+        const int x2 = qBound(0, x1 + w, width);
+        const int y2 = qBound(0, y1 + h, height);
+        QCOMPARE(x1, 10);
+        QCOMPARE(y1, 10);
+        QCOMPARE(x2, 110);
+        QCOMPARE(y2, 110);
+    }
+
+    // Region partially outside right edge: (1900,10,100,100) -> x2 clamped to 1920
+    {
+        int x = 1900, y = 10, w = 100, h = 100;
+        const int x1 = qBound(0, x, width);
+        const int y1 = qBound(0, y, height);
+        const int x2 = qBound(0, x1 + w, width);
+        const int y2 = qBound(0, y1 + h, height);
+        QCOMPARE(x1, 1900);
+        QCOMPARE(y1, 10);
+        QCOMPARE(x2, 1920);
+        QCOMPARE(y2, 110);
+    }
+
+    // Region completely outside: (2000,2000,100,100) -> x1=y1=1920,1080 -> x2=y2=1920,1080 -> invalid (not x2>x1)
+    {
+        int x = 2000, y = 2000, w = 100, h = 100;
+        const int x1 = qBound(0, x, width);
+        const int y1 = qBound(0, y, height);
+        const int x2 = qBound(0, x1 + w, width);
+        const int y2 = qBound(0, y1 + h, height);
+        QCOMPARE(x1, 1920);
+        QCOMPARE(y1, 1080);
+        QCOMPARE(x2, 1920);
+        QCOMPARE(y2, 1080);
+        QVERIFY(x2 <= x1);
+        QVERIFY(y2 <= y1);
+    }
+
+    // Negative position: (-10,-10,100,100) -> x1=y1=0 -> x2=100,y2=100
+    {
+        int x = -10, y = -10, w = 100, h = 100;
+        const int x1 = qBound(0, x, width);
+        const int y1 = qBound(0, y, height);
+        const int x2 = qBound(0, x1 + w, width);
+        const int y2 = qBound(0, y1 + h, height);
+        QCOMPARE(x1, 0);
+        QCOMPARE(y1, 0);
+        QCOMPARE(x2, 100);
+        QCOMPARE(y2, 100);
+    }
+}
+
+void PipeWireVncServerTest::testPortalTokenPattern()
+{
+    // makeRequestToken() should return "veyon_" followed by a numeric part
+    QVERIFY(QString("veyon_%1").arg(12345).startsWith("veyon_"));
+    QVERIFY(QString("veyon_%1").arg(0).startsWith("veyon_"));
+    QVERIFY(QString("veyon_%1").arg(999999).startsWith("veyon_"));
+
+    // Verify the numeric part is present after the prefix
+    QString token = QString("veyon_%1").arg(12345);
+    QCOMPARE(token, QString("veyon_12345"));
+}
+
+void PipeWireVncServerTest::testPortalRequestPath()
+{
+    // Test makeRequestPath format: /org/freedesktop/portal/desktop/request/%1/%2
+    const QString senderToken = "sender123";
+    const QString requestToken = "req456";
+    QString path = QString("/org/freedesktop/portal/desktop/request/%1/%2")
+                       .arg(senderToken, requestToken);
+    QCOMPARE(path, QString("/org/freedesktop/portal/desktop/request/sender123/req456"));
+    QVERIFY(path.startsWith("/org/freedesktop/portal/desktop/request/"));
+    QVERIFY(path.endsWith("/req456"));
+
+    // Test with empty tokens
+    QString pathEmpty = QString("/org/freedesktop/portal/desktop/request/%1/%2")
+                            .arg(QString(), QString());
+    QCOMPARE(pathEmpty, QString("/org/freedesktop/portal/desktop/request//"));
+
+    // Test with special characters in tokens
+    QString pathSpecial = QString("/org/freedesktop/portal/desktop/request/%1/%2")
+                              .arg(QString("test_user"), QString("req_42"));
+    QCOMPARE(pathSpecial, QString("/org/freedesktop/portal/desktop/request/test_user/req_42"));
+}
+
+QTEST_MAIN(PipeWireVncServerTest)
+#include "PipeWireVncServerTest.moc"


### PR DESCRIPTION
### Platform layer (Wayland-aware replacements for X11-only code)
- **Screen saver inhibition**: `org.freedesktop.portal.Inhibit` /
  `org.freedesktop.ScreenSaver` DBus interface (X11/DPMS path preserved)
- **Input device blocking**: `EVIOCGRAB` on `/dev/input/event*` devices
  (X11 keymap manipulation path preserved)
- **Keyboard input injection**: uinput virtual keyboard (`/dev/uinput`)
  with full keysym→keycode mapping table (libfakekey/XTest path preserved)
All components check the `WAYLAND_DISPLAY` environment variable at runtime.
### PipeWire VNC server fixes
- Default implementation flag for Wayland sessions
- Bundled LibVNCServer support (system version < 0.9.8)
- Portal D-Bus connection fix (default session bus instead of private connection)
- Unified app ID (`io.veyon.veyon-server`)
- Missing includes for Qt6 builds
### Tests
230 keyboard mapping tests + 6 PipeWire VNC server tests (all passing).