### PR TITLE
ScreenLock: don't lock the master computer itself

### DIFF
--- a/core/src/ComputerControlInterface.cpp
+++ b/core/src/ComputerControlInterface.cpp
@@ -27,6 +27,7 @@
 #include "ComputerControlInterface.h"
 #include "Computer.h"
 #include "FeatureManager.h"
+#include "HostAddress.h"
 #include "MonitoringMode.h"
 #include "VeyonConfiguration.h"
 #include "VeyonConnection.h"
@@ -638,4 +639,21 @@ QDebug operator<<(QDebug stream, const ComputerControlInterfaceList& computerCon
 	stream << QStringLiteral("[%1]").arg(hostAddresses.join(QLatin1Char(','))).toUtf8().constData();
 
 	return stream;
+}
+
+
+
+void ComputerControlInterfaceList::removeLocalHostInterfaces()
+{
+	for (auto it = begin(); it != end(); )
+	{
+		if (HostAddress(HostAddress::parseHost((*it)->computer().hostName())).isLocalHost())
+		{
+			it = erase(it);
+		}
+		else
+		{
+			++it;
+		}
+	}
 }

--- a/core/src/ComputerControlInterface.h
+++ b/core/src/ComputerControlInterface.h
@@ -254,7 +254,14 @@ Q_SIGNALS:
 
 };
 
-using ComputerControlInterfaceList = QVector<ComputerControlInterface::Pointer>;
+class VEYON_CORE_EXPORT ComputerControlInterfaceList : public QList<ComputerControlInterface::Pointer>
+{
+public:
+	using QList::QList;
+
+	// removes all interfaces that refer to the local computer (i.e. the master itself)
+	void removeLocalHostInterfaces();
+};
 
 VEYON_CORE_EXPORT QDebug operator<<(QDebug stream, ComputerControlInterface::Pointer computerControlInterface);
 VEYON_CORE_EXPORT QDebug operator<<(QDebug stream, const ComputerControlInterfaceList& computerControlInterfaces);

--- a/plugins/demo/DemoFeaturePlugin.cpp
+++ b/plugins/demo/DemoFeaturePlugin.cpp
@@ -27,6 +27,7 @@
 
 #include "AuthenticationCredentials.h"
 #include "Computer.h"
+#include "ComputerControlInterface.h"
 #include "CryptoCore.h"
 #include "DemoClient.h"
 #include "DemoConfigurationPage.h"
@@ -233,17 +234,7 @@ bool DemoFeaturePlugin::startFeature( VeyonMasterInterface& master, const Featur
 		// computer itself: it is listed as a regular room computer but has to
 		// keep control over the running demonstration - it receives a dedicated
 		// window demo below instead
-		for (auto it = userDemoControlInterfaces.begin(); it != userDemoControlInterfaces.end(); )
-		{
-			if (HostAddress(HostAddress::parseHost((*it)->computer().hostName())).isLocalHost())
-			{
-				it = userDemoControlInterfaces.erase(it);
-			}
-			else
-			{
-				++it;
-			}
-		}
+		userDemoControlInterfaces.removeLocalHostInterfaces();
 
 		const QVariantMap demoClientArgs{
 			{ argToString(Argument::DemoServerHost), HostAddress::parseHost(demoServerHost) },

--- a/plugins/screenlock/ScreenLockFeaturePlugin.cpp
+++ b/plugins/screenlock/ScreenLockFeaturePlugin.cpp
@@ -25,6 +25,7 @@
 #include <QCoreApplication>
 
 #include "ScreenLockFeaturePlugin.h"
+#include "ComputerControlInterface.h"
 #include "FeatureWorkerManager.h"
 #include "LockWidget.h"
 #include "PlatformCoreFunctions.h"
@@ -88,7 +89,14 @@ bool ScreenLockFeaturePlugin::controlFeature( Feature::Uid featureUid, Operation
 
 	if( operation == Operation::Start )
 	{
-		sendFeatureMessage(FeatureMessage{featureUid, FeatureCommand::StartLock}, computerControlInterfaces);
+		// never lock the master computer itself: in multi-teacher lab layouts it
+		// is listed as a regular room computer, but locking its screen would grab
+		// the teacher's keyboard and mouse and cover Veyon Master, leaving no way
+		// to unlock the running session
+		auto lockControlInterfaces = computerControlInterfaces;
+		lockControlInterfaces.removeLocalHostInterfaces();
+
+		sendFeatureMessage(FeatureMessage{featureUid, FeatureCommand::StartLock}, lockControlInterfaces);
 
 		return true;
 	}


### PR DESCRIPTION
As suggested in #1126, the same self-lock problem affects the Screen Lock feature.

When the master's own computer is part of the room (e.g. a multi-teacher lab where the teacher station is listed as a regular computer), locking the screen of all selected computers also locks the master itself: the fullscreen LockWidget grabs keyboard and mouse and covers Veyon Master, so the teacher cannot unlock the running session.

This excludes the local host from the screen lock broadcast. The local-host filtering already done by the demo feature (#1126) is factored out into a reusable `removeLocalHostInterfaces()` helper in core and used by both features, so the loop is no longer duplicated.

Tested on ALT Education (Qt6 / KDE X11): locking a room that includes the master no longer locks the master, while remote computers still lock as before.