### PR TITLE
plugins/linux: fix Wayland session environment and user credentials

### DIFF
--- a/.ci/linux.debian.11/Dockerfile
+++ b/.ci/linux.debian.11/Dockerfile
@@ -7,6 +7,7 @@ RUN \
 		dpkg-dev \
 		ca-certificates git binutils gcc g++ ninja-build cmake file fakeroot bzip2 \
 		qtbase5-dev qtbase5-private-dev qtbase5-dev-tools qttools5-dev qttools5-dev-tools qtdeclarative5-dev qtquickcontrols2-5-dev \
+		libpipewire-0.3-dev libspa-0.2-dev \
 		xorg-dev \
 		libfakekey-dev \
 		libvncserver-dev \

--- a/.ci/linux.debian.12/Dockerfile
+++ b/.ci/linux.debian.12/Dockerfile
@@ -7,6 +7,7 @@ RUN \
 		dpkg-dev \
 		ca-certificates git binutils gcc g++ ninja-build cmake file fakeroot bzip2 \
 		qtbase5-dev qtbase5-private-dev qtbase5-dev-tools qttools5-dev qttools5-dev-tools qtdeclarative5-dev qtquickcontrols2-5-dev \
+		libpipewire-0.3-dev libspa-0.2-dev \
 		xorg-dev \
 		libfakekey-dev \
 		libpng-dev libjpeg-dev zlib1g-dev liblzo2-dev \

--- a/.ci/linux.debian.13/Dockerfile
+++ b/.ci/linux.debian.13/Dockerfile
@@ -7,6 +7,7 @@ RUN \
 		dpkg-dev \
 		ca-certificates git binutils gcc g++ ninja-build cmake file fakeroot bzip2 \
 		qt6-base-dev qt6-5compat-dev qt6-l10n-tools qt6-tools-dev qt6-declarative-dev qt6-httpserver-dev qt6-websockets-dev \
+		libpipewire-0.3-dev libspa-0.2-dev \
 		xorg-dev \
 		libfakekey-dev \
 		libvncserver-dev \

--- a/.ci/linux.fedora.43/Dockerfile
+++ b/.ci/linux.fedora.43/Dockerfile
@@ -7,6 +7,7 @@ RUN \
 		git gcc-c++ ninja-build cmake rpm-build fakeroot fakeroot-libs \
 		qt6-qtbase-devel qt6-qtbase qt6-qt5compat-devel qt6-linguist qt6-qttools-devel qt6-qtdeclarative-devel qt6-qthttpserver-devel \
 		libXtst-devel libXrandr-devel libXinerama-devel libXcursor-devel libXrandr-devel libXdamage-devel libXcomposite-devel libXfixes-devel \
+		pipewire-devel \
 		libfakekey-devel \
 		libvncserver-devel \
 		openssl-devel \

--- a/.ci/linux.fedora.44/Dockerfile
+++ b/.ci/linux.fedora.44/Dockerfile
@@ -7,6 +7,7 @@ RUN \
 		git gcc-c++ ninja-build cmake rpm-build fakeroot fakeroot-libs \
 		qt6-qtbase-devel qt6-qtbase qt6-qt5compat-devel qt6-linguist qt6-qttools-devel qt6-qtdeclarative-devel qt6-qthttpserver-devel \
 		libXtst-devel libXrandr-devel libXinerama-devel libXcursor-devel libXrandr-devel libXdamage-devel libXcomposite-devel libXfixes-devel \
+		pipewire-devel \
 		libfakekey-devel \
 		libvncserver-devel \
 		openssl-devel \

--- a/.ci/linux.opensuse.leap.16.0/Dockerfile
+++ b/.ci/linux.opensuse.leap.16.0/Dockerfile
@@ -5,6 +5,7 @@ RUN \
 	zypper --gpg-auto-import-keys install -y git gcc-c++ ninja cmake rpm-build fakeroot \
 		qt6-widgets-devel qt6-qt5compat-devel qt6-concurrent-devel qt6-linguist-devel qt6-tools-devel qt6-quickcontrols2-devel qt6-httpserver-devel \
 		libXtst-devel libXrandr-devel libXinerama-devel libXcursor-devel libXrandr-devel libXdamage-devel libXcomposite-devel libXfixes-devel \
+		pipewire-devel \
 		libfakekey-devel \
 		LibVNCServer-devel \
 		libjpeg8-devel \

--- a/.ci/linux.opensuse.tumbleweed/Dockerfile
+++ b/.ci/linux.opensuse.tumbleweed/Dockerfile
@@ -5,6 +5,7 @@ RUN \
 	zypper --gpg-auto-import-keys install -y git gcc-c++ ninja cmake rpm-build fakeroot \
 		qt6-widgets-devel qt6-qt5compat-devel qt6-concurrent-devel qt6-linguist-devel qt6-tools-devel qt6-quickcontrols2-devel qt6-httpserver-devel \
 		libXtst-devel libXrandr-devel libXinerama-devel libXcursor-devel libXrandr-devel libXdamage-devel libXcomposite-devel libXfixes-devel \
+		pipewire-devel \
 		libfakekey-devel \
 		LibVNCServer-devel \
 		libjpeg8-devel \

--- a/.ci/linux.rhel.10/Dockerfile
+++ b/.ci/linux.rhel.10/Dockerfile
@@ -8,6 +8,7 @@ RUN \
 		git ninja-build cmake rpm-build fakeroot \
 		qt6-qtbase-devel qt6-qtbase qt6-qt5compat-devel qt6-linguist qt6-qttools-devel qt6-qtdeclarative-devel qt6-qthttpserver-devel \
 		libXtst-devel libXrandr-devel libXinerama-devel libXcursor-devel libXrandr-devel libXdamage-devel libXcomposite-devel libXfixes-devel \
+		pipewire-devel \
 		libfakekey-devel \
 		libjpeg-turbo-devel zlib-devel libpng-devel lzo-devel \
 		libvncserver-devel \

--- a/.ci/linux.ubuntu.24.04/Dockerfile
+++ b/.ci/linux.ubuntu.24.04/Dockerfile
@@ -7,6 +7,7 @@ RUN \
 		dpkg-dev \
 		ca-certificates git binutils gcc g++ ninja-build cmake file fakeroot bzip2 \
 		qt6-base-dev qt6-5compat-dev qt6-l10n-tools qt6-tools-dev qt6-declarative-dev qt6-httpserver-dev qt6-websockets-dev \
+		libpipewire-0.3-dev libspa-0.2-dev \
 		xorg-dev \
 		libfakekey-dev \
 		libvncserver-dev \

--- a/.ci/linux.ubuntu.26.04/Dockerfile
+++ b/.ci/linux.ubuntu.26.04/Dockerfile
@@ -7,6 +7,7 @@ RUN \
 		dpkg-dev \
 		ca-certificates git binutils gcc g++ ninja-build cmake file fakeroot bzip2 \
 		qt6-base-dev qt6-5compat-dev qt6-l10n-tools qt6-tools-dev qt6-declarative-dev qt6-httpserver-dev qt6-websockets-dev \
+		libpipewire-0.3-dev libspa-0.2-dev \
 		xorg-dev \
 		libfakekey-dev \
 		libvncserver-dev \

--- a/cmake/modules/FindPipeWire.cmake
+++ b/cmake/modules/FindPipeWire.cmake
@@ -1,0 +1,61 @@
+# FindPipeWire.cmake - find PipeWire library
+#
+# Copyright (c) 2024-2026 Tobias Junghans <tobydox@veyon.io>
+#
+# This file is part of Veyon - https://veyon.io
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This module defines:
+#   PipeWire_FOUND        - system has PipeWire
+#   PipeWire_INCLUDE_DIRS - include directories
+#   PipeWire_LIBRARIES    - libraries to link against
+#   PipeWire_VERSION      - version string
+#   PipeWire::PipeWire    - imported target
+
+find_package(PkgConfig QUIET)
+
+if(PKG_CONFIG_FOUND)
+	pkg_check_modules(PC_PIPEWIRE QUIET libpipewire-0.3)
+endif()
+
+find_path(PipeWire_INCLUDE_DIR
+	NAMES pipewire/pipewire.h
+	HINTS ${PC_PIPEWIRE_INCLUDE_DIRS}
+	PATH_SUFFIXES pipewire-0.3
+)
+
+find_library(PipeWire_LIBRARY
+	NAMES pipewire-0.3
+	HINTS ${PC_PIPEWIRE_LIBRARY_DIRS}
+)
+
+# Also look for spa headers which come with pipewire
+find_path(Spa_INCLUDE_DIR
+	NAMES spa/param/video/format-utils.h
+	HINTS ${PC_PIPEWIRE_INCLUDE_DIRS}
+	PATH_SUFFIXES spa-0.2
+)
+
+set(PipeWire_VERSION ${PC_PIPEWIRE_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PipeWire
+	REQUIRED_VARS PipeWire_LIBRARY PipeWire_INCLUDE_DIR Spa_INCLUDE_DIR
+	VERSION_VAR PipeWire_VERSION
+)
+
+if(PipeWire_FOUND)
+	set(PipeWire_INCLUDE_DIRS ${PipeWire_INCLUDE_DIR} ${Spa_INCLUDE_DIR})
+	set(PipeWire_LIBRARIES ${PipeWire_LIBRARY})
+
+	if(NOT TARGET PipeWire::PipeWire)
+		add_library(PipeWire::PipeWire UNKNOWN IMPORTED)
+		set_target_properties(PipeWire::PipeWire PROPERTIES
+			IMPORTED_LOCATION "${PipeWire_LIBRARY}"
+			INTERFACE_INCLUDE_DIRECTORIES "${PipeWire_INCLUDE_DIRS}"
+		)
+	endif()
+endif()
+
+mark_as_advanced(PipeWire_INCLUDE_DIR PipeWire_LIBRARY Spa_INCLUDE_DIR)

--- a/core/src/MonitoringMode.cpp
+++ b/core/src/MonitoringMode.cpp
@@ -27,6 +27,7 @@
 #include <QGuiApplication>
 #include <QInputDialog>
 #include <QLineEdit>
+#include <QPointer>
 #include <QScreen>
 
 #include "FeatureManager.h"
@@ -485,44 +486,67 @@ void MonitoringMode::updateUserInfo()
 {
 	// asynchronously query information about logged on user (which might block
 	// due to domain controller queries and timeouts etc.)
-	(void) QtConcurrent::run([=, this]() {
+	const auto guard = QPointer<MonitoringMode>(this);
+	(void) QtConcurrent::run([guard]() {
+		if(!guard)
+		{
+			return;
+		}
+
 		if( VeyonCore::platform().sessionFunctions().currentSessionHasUser() )
 		{
 			const auto userLoginName = VeyonCore::platform().userFunctions().queryCurrentUserProperty(PlatformUserFunctions::UserProperty::LoginName);
 			const auto userFullName = VeyonCore::platform().userFunctions().queryCurrentUserProperty(PlatformUserFunctions::UserProperty::FullName);
-			m_userDataLock.lockForWrite();
-			if(m_userLoginName != userLoginName ||
-			   m_userFullName != userFullName)
+
+			if(!guard)
 			{
-				m_userLoginName = userLoginName;
-				m_userFullName = userFullName;
-				++m_userInfoVersion;
+				return;
 			}
-			m_userDataLock.unlock();
+
+			guard->m_userDataLock.lockForWrite();
+			if(guard->m_userLoginName != userLoginName ||
+			   guard->m_userFullName != userFullName)
+			{
+				guard->m_userLoginName = userLoginName;
+				guard->m_userFullName = userFullName;
+				++guard->m_userInfoVersion;
+			}
+			guard->m_userDataLock.unlock();
 		}
 
-		m_userDataLock.lockForRead();
-		if (m_userLoginName.isEmpty() && m_userFullName.isEmpty())
+		if(!guard)
 		{
-			QTimer::singleShot(UserInfoUpdateRetryInterval, this, &MonitoringMode::updateUserInfo);
+			return;
 		}
-		m_userDataLock.unlock();
-	} );
+
+		guard->m_userDataLock.lockForRead();
+		if (guard->m_userLoginName.isEmpty() && guard->m_userFullName.isEmpty())
+		{
+			QTimer::singleShot(UserInfoUpdateRetryInterval, guard, &MonitoringMode::updateUserInfo);
+		}
+		guard->m_userDataLock.unlock();
+	});
 }
 
 
 
 void MonitoringMode::updateSessionInfo()
 {
-	(void) QtConcurrent::run([=, this]() {
+	const auto guard = QPointer<MonitoringMode>(this);
+	(void) QtConcurrent::run([guard]() {
+		if(!guard)
+		{
+			return;
+		}
+
 		QString sessionMetaData;
-		switch (m_sessionMetaDataContent)
+		switch (guard->m_sessionMetaDataContent)
 		{
 		case PlatformSessionFunctions::SessionMetaDataContent::EnvironmentVariable:
-			sessionMetaData = VeyonCore::platform().sessionFunctions().currentSessionEnvironmentVariables().value(m_sessionMetaDataEnvironmentVariable);
+			sessionMetaData = VeyonCore::platform().sessionFunctions().currentSessionEnvironmentVariables().value(guard->m_sessionMetaDataEnvironmentVariable);
 			break;
 		case PlatformSessionFunctions::SessionMetaDataContent::RegistryKey:
-			sessionMetaData = VeyonCore::platform().sessionFunctions().querySettingsValueInCurrentSession(m_sessionMetaDataRegistryKey).toString();
+			sessionMetaData = VeyonCore::platform().sessionFunctions().querySettingsValueInCurrentSession(guard->m_sessionMetaDataRegistryKey).toString();
 			break;
 		case PlatformSessionFunctions::SessionMetaDataContent::None:
 			break;
@@ -537,13 +561,18 @@ void MonitoringMode::updateSessionInfo()
 					sessionMetaData
 		};
 
-		m_sessionInfoLock.lockForWrite();
-		if (currentSessionInfo != m_sessionInfo)
+		if(!guard)
 		{
-			m_sessionInfo = currentSessionInfo;
-			++m_sessionInfoVersion;
+			return;
 		}
-		m_sessionInfoLock.unlock();
+
+		guard->m_sessionInfoLock.lockForWrite();
+		if (currentSessionInfo != guard->m_sessionInfo)
+		{
+			guard->m_sessionInfo = currentSessionInfo;
+			++guard->m_sessionInfoVersion;
+		}
+		guard->m_sessionInfoLock.unlock();
 	});
 }
 

--- a/plugins/platform/linux/LinuxCoreFunctions.cpp
+++ b/plugins/platform/linux/LinuxCoreFunctions.cpp
@@ -22,8 +22,12 @@
  *
  */
 
+#include <QCoreApplication>
 #include <QElapsedTimer>
 #include <QFileInfo>
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QDBusObjectPath>
 #include <QDBusPendingCall>
 #include <QProcess>
 #include <QProcessEnvironment>
@@ -45,6 +49,13 @@
 
 #include <X11/XKBlib.h>
 #include <X11/extensions/dpms.h>
+
+
+LinuxCoreFunctions::LinuxCoreFunctions() :
+	m_isWaylandSession(qEnvironmentVariableIsSet("WAYLAND_DISPLAY"))
+{
+}
+
 
 
 bool LinuxCoreFunctions::prepareSessionBusAccess()
@@ -146,6 +157,13 @@ void LinuxCoreFunctions::raiseWindow( QWidget* widget, bool stayOnTop )
 
 void LinuxCoreFunctions::disableScreenSaver()
 {
+	// On Wayland use DBus-based inhibition
+	if (m_isWaylandSession)
+	{
+		disableScreenSaverWayland();
+		return;
+	}
+
 	auto display = XOpenDisplay( nullptr );
 
 	// query and disable screen saver
@@ -186,6 +204,13 @@ void LinuxCoreFunctions::disableScreenSaver()
 
 void LinuxCoreFunctions::restoreScreenSaverSettings()
 {
+	// On Wayland use DBus-based restoration
+	if (m_isWaylandSession)
+	{
+		restoreScreenSaverSettingsWayland();
+		return;
+	}
+
 	auto display = XOpenDisplay( nullptr );
 
 	// restore screensaver settings
@@ -210,6 +235,99 @@ void LinuxCoreFunctions::restoreScreenSaverSettings()
 
 	XFlush( display );
 	XCloseDisplay( display );
+}
+
+
+
+void LinuxCoreFunctions::disableScreenSaverWayland()
+{
+	// Try org.freedesktop.portal.Inhibit first (xdg-desktop-portal, works on all DEs)
+	const auto appName = QCoreApplication::applicationName();
+
+	QDBusMessage inhibitPortal = QDBusMessage::createMethodCall(
+		QStringLiteral("org.freedesktop.portal.Desktop"),
+		QStringLiteral("/org/freedesktop/portal/desktop"),
+		QStringLiteral("org.freedesktop.portal.Inhibit"),
+		QStringLiteral("Inhibit"));
+	inhibitPortal.setArguments({
+		QVariant::fromValue(QDBusObjectPath(QStringLiteral("/"))),
+		QVariant::fromValue(appName),
+		QVariant::fromValue(QStringLiteral("remote-desktop")),
+		QVariant::fromValue(QVariantMap{})
+	});
+	QDBusMessage reply = QDBusConnection::sessionBus().call(inhibitPortal, QDBus::BlockWithGui, 2000);
+
+	if (reply.type() == QDBusMessage::ReplyMessage)
+	{
+		m_waylandInhibitCookie = reply.arguments().value(0).toUInt();
+		vDebug() << "Screen saver inhibited via portal, cookie:" << m_waylandInhibitCookie;
+		return;
+	}
+
+	vDebug() << "Portal Inhibit not available, trying org.freedesktop.ScreenSaver";
+
+	// Fallback: org.freedesktop.ScreenSaver (older DEs)
+	QDBusMessage inhibitFreeDesktop = QDBusMessage::createMethodCall(
+		QStringLiteral("org.freedesktop.ScreenSaver"),
+		QStringLiteral("/ScreenSaver"),
+		QStringLiteral("org.freedesktop.ScreenSaver"),
+		QStringLiteral("Inhibit"));
+	inhibitFreeDesktop.setArguments({
+		QVariant::fromValue(appName),
+		QVariant::fromValue(QStringLiteral("Veyon remote desktop session"))
+	});
+	QDBusMessage reply2 = QDBusConnection::sessionBus().call(inhibitFreeDesktop, QDBus::BlockWithGui, 2000);
+
+	if (reply2.type() == QDBusMessage::ReplyMessage)
+	{
+		m_waylandInhibitCookie = reply2.arguments().value(0).toUInt();
+		vDebug() << "Screen saver inhibited via org.freedesktop.ScreenSaver, cookie:" << m_waylandInhibitCookie;
+		return;
+	}
+
+	vWarning() << "Could not inhibit screen saver on Wayland - no portal or DBus interface available";
+}
+
+
+
+void LinuxCoreFunctions::restoreScreenSaverSettingsWayland()
+{
+	if (m_waylandInhibitCookie == 0)
+	{
+		return;
+	}
+
+	// Try portal UnInhibit first
+	QDBusMessage unInhibitPortal = QDBusMessage::createMethodCall(
+		QStringLiteral("org.freedesktop.portal.Desktop"),
+		QStringLiteral("/org/freedesktop/portal/desktop"),
+		QStringLiteral("org.freedesktop.portal.Inhibit"),
+		QStringLiteral("UnInhibit"));
+	unInhibitPortal.setArguments({
+		QVariant::fromValue(m_waylandInhibitCookie)
+	});
+	QDBusMessage reply = QDBusConnection::sessionBus().call(unInhibitPortal, QDBus::BlockWithGui, 2000);
+
+	if (reply.type() == QDBusMessage::ReplyMessage || reply.type() == QDBusMessage::ErrorMessage)
+	{
+		vDebug() << "Screen saver restored via portal";
+		m_waylandInhibitCookie = 0;
+		return;
+	}
+
+	// Fallback: org.freedesktop.ScreenSaver UnInhibit
+	QDBusMessage unInhibitFreeDesktop = QDBusMessage::createMethodCall(
+		QStringLiteral("org.freedesktop.ScreenSaver"),
+		QStringLiteral("/ScreenSaver"),
+		QStringLiteral("org.freedesktop.ScreenSaver"),
+		QStringLiteral("UnInhibit"));
+	unInhibitFreeDesktop.setArguments({
+		QVariant::fromValue(m_waylandInhibitCookie)
+	});
+	QDBusConnection::sessionBus().call(unInhibitFreeDesktop, QDBus::BlockWithGui, 2000);
+
+	m_waylandInhibitCookie = 0;
+	vDebug() << "Screen saver restored via org.freedesktop.ScreenSaver";
 }
 
 

--- a/plugins/platform/linux/LinuxCoreFunctions.h
+++ b/plugins/platform/linux/LinuxCoreFunctions.h
@@ -24,7 +24,10 @@
 
 #pragma once
 
+#include <QDBusConnection>
 #include <QDBusInterface>
+#include <QDBusMessage>
+#include <QDBusPendingCall>
 #include <QSharedPointer>
 
 #include "PlatformCoreFunctions.h"
@@ -44,7 +47,7 @@ struct proc_t;
 class LinuxCoreFunctions : public PlatformCoreFunctions
 {
 public:
-	LinuxCoreFunctions() = default;
+	LinuxCoreFunctions();
 
 	bool applyConfiguration() override;
 
@@ -109,5 +112,13 @@ private:
 	unsigned short m_dpmsStandbyTimeout{0};
 	unsigned short m_dpmsSuspendTimeout{0};
 	unsigned short m_dpmsOffTimeout{0};
+
+	// Wayland screen saver inhibition via DBus
+	const bool m_isWaylandSession;
+	static constexpr auto WaylandScreenSaverInhibitCookie = 0;
+	unsigned m_waylandInhibitCookie{0};
+
+	void disableScreenSaverWayland();
+	void restoreScreenSaverSettingsWayland();
 
 };

--- a/plugins/platform/linux/LinuxInputDeviceFunctions.cpp
+++ b/plugins/platform/linux/LinuxInputDeviceFunctions.cpp
@@ -22,33 +22,65 @@
  *
  */
 
+#include <QDir>
+#include <QFile>
+
 #include "PlatformServiceFunctions.h"
 #include "LinuxInputDeviceFunctions.h"
 #include "LinuxKeyboardShortcutTrapper.h"
 
+
+LinuxInputDeviceFunctions::LinuxInputDeviceFunctions() :
+	m_isWaylandSession(qEnvironmentVariableIsSet("WAYLAND_DISPLAY"))
+{
+}
+
 #include <X11/XKBlib.h>
+
+#include <fcntl.h>
+#include <linux/input.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
 
 
 void LinuxInputDeviceFunctions::enableInputDevices()
 {
-	if( m_inputDevicesDisabled )
+	if( m_inputDevicesDisabled == false )
+	{
+		return;
+	}
+
+	if (m_isWaylandSession)
+	{
+		enableInputDevicesWayland();
+	}
+	else
 	{
 		restoreKeyMapTable();
-
-		m_inputDevicesDisabled = false;
 	}
+
+	m_inputDevicesDisabled = false;
 }
 
 
 
 void LinuxInputDeviceFunctions::disableInputDevices()
 {
-	if( m_inputDevicesDisabled == false )
+	if( m_inputDevicesDisabled )
+	{
+		return;
+	}
+
+	if (m_isWaylandSession)
+	{
+		disableInputDevicesWayland();
+	}
+	else
 	{
 		setEmptyKeyMapTable();
-
-		m_inputDevicesDisabled = true;
 	}
+
+	m_inputDevicesDisabled = true;
 }
 
 
@@ -100,4 +132,86 @@ void LinuxInputDeviceFunctions::restoreKeyMapTable()
 
 	XFree( m_origKeyTable );
 	m_origKeyTable = nullptr;
+}
+
+
+
+// ---------------------------------------------------------------------------
+// Wayland input device blocking via evdev EVIOCGRAB
+// ---------------------------------------------------------------------------
+
+int LinuxInputDeviceFunctions::openAndGrabInputDevice(const QString& path)
+{
+	const int fd = ::open( path.toUtf8().constData(), O_RDWR | O_NONBLOCK );
+	if( fd < 0 )
+	{
+		return -1;
+	}
+
+	// Try to grab the device exclusively. This prevents Wayland/compositor
+	// from receiving events from this device while we hold the grab.
+	if( ::ioctl( fd, EVIOCGRAB, reinterpret_cast<void*>( 1L ) ) < 0 )
+	{
+		::close( fd );
+		return -1;
+	}
+
+	return fd;
+}
+
+
+
+void LinuxInputDeviceFunctions::disableInputDevicesWayland()
+{
+	// Close any previously grabbed devices first
+	enableInputDevicesWayland();
+
+	const QDir inputDir( QStringLiteral("/dev/input") );
+	if( inputDir.exists() == false )
+	{
+		vWarning() << "No /dev/input directory found - cannot grab input devices on Wayland";
+		return;
+	}
+
+	const auto eventFiles = inputDir.entryList( { QStringLiteral("event*") }, QDir::System | QDir::Files );
+	for( const auto& eventFile : eventFiles )
+	{
+		const auto devicePath = inputDir.absoluteFilePath( eventFile );
+
+		// Skip touchpads and other non-keyboard devices? We grab all input
+		// devices to ensure complete input blocking for classroom control.
+		const int fd = openAndGrabInputDevice( devicePath );
+		if( fd >= 0 )
+		{
+			m_grabbedDeviceFds.append( fd );
+			vDebug() << "Grabbed input device:" << devicePath;
+		}
+	}
+
+	if( m_grabbedDeviceFds.isEmpty() )
+	{
+		vWarning() << "Could not grab any input device - you might need to run as root";
+	}
+	else
+	{
+		vInfo() << "Grabbed" << m_grabbedDeviceFds.size() << "input devices on Wayland";
+	}
+}
+
+
+
+void LinuxInputDeviceFunctions::enableInputDevicesWayland()
+{
+	for( const auto fd : std::as_const( m_grabbedDeviceFds ) )
+	{
+		// Release the grab
+		if( fd >= 0 )
+		{
+			::ioctl( fd, EVIOCGRAB, reinterpret_cast<void*>( 0L ) );
+			::close( fd );
+		}
+	}
+
+	m_grabbedDeviceFds.clear();
+	vDebug() << "Released all grabbed input devices";
 }

--- a/plugins/platform/linux/LinuxInputDeviceFunctions.h
+++ b/plugins/platform/linux/LinuxInputDeviceFunctions.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <QList>
+
 #include "PlatformInputDeviceFunctions.h"
 
 // clazy:excludeall=copyable-polymorphic
@@ -31,7 +33,7 @@
 class LinuxInputDeviceFunctions : public PlatformInputDeviceFunctions
 {
 public:
-	LinuxInputDeviceFunctions() = default;
+	LinuxInputDeviceFunctions();
 	virtual ~LinuxInputDeviceFunctions() = default;
 
 	void enableInputDevices() override;
@@ -43,11 +45,21 @@ private:
 	void setEmptyKeyMapTable();
 	void restoreKeyMapTable();
 
+	// Wayland input device blocking via uinput + evdev grab
+	void disableInputDevicesWayland();
+	void enableInputDevicesWayland();
+	int openAndGrabInputDevice(const QString& path);
+
 	bool m_inputDevicesDisabled{false};
 	void* m_origKeyTable{nullptr};
 	int m_keyCodeMin{0};
 	int m_keyCodeMax{0};
 	int m_keyCodeCount{0};
 	int m_keySymsPerKeyCode{0};
+
+	// Wayland: grabbed input device FDs (owned, need close)
+	QList<int> m_grabbedDeviceFds;
+
+	const bool m_isWaylandSession;
 
 };

--- a/plugins/platform/linux/LinuxKeyboardInput.cpp
+++ b/plugins/platform/linux/LinuxKeyboardInput.cpp
@@ -213,140 +213,147 @@ void LinuxKeyboardInput::pressAndReleaseKeyUinputUtf8( const QByteArray& utf8Dat
 
 int LinuxKeyboardInput::keysymToLinuxKeycode( uint32_t keysym )
 {
-	switch( keysym )
+	static constexpr struct { uint32_t keysym; int keycode; } table[] = {
+		{ XK_Escape,       KEY_ESC },
+		{ XK_1,            KEY_1 },
+		{ XK_2,            KEY_2 },
+		{ XK_3,            KEY_3 },
+		{ XK_4,            KEY_4 },
+		{ XK_5,            KEY_5 },
+		{ XK_6,            KEY_6 },
+		{ XK_7,            KEY_7 },
+		{ XK_8,            KEY_8 },
+		{ XK_9,            KEY_9 },
+		{ XK_0,            KEY_0 },
+		{ XK_minus,        KEY_MINUS },
+		{ XK_equal,        KEY_EQUAL },
+		{ XK_BackSpace,    KEY_BACKSPACE },
+		{ XK_Tab,          KEY_TAB },
+		{ XK_q,            KEY_Q },
+		{ XK_w,            KEY_W },
+		{ XK_e,            KEY_E },
+		{ XK_r,            KEY_R },
+		{ XK_t,            KEY_T },
+		{ XK_y,            KEY_Y },
+		{ XK_u,            KEY_U },
+		{ XK_i,            KEY_I },
+		{ XK_o,            KEY_O },
+		{ XK_p,            KEY_P },
+		{ XK_bracketleft,  KEY_LEFTBRACE },
+		{ XK_bracketright, KEY_RIGHTBRACE },
+		{ XK_Return,       KEY_ENTER },
+		{ XK_Control_L,    KEY_LEFTCTRL },
+		{ XK_a,            KEY_A },
+		{ XK_s,            KEY_S },
+		{ XK_d,            KEY_D },
+		{ XK_f,            KEY_F },
+		{ XK_g,            KEY_G },
+		{ XK_h,            KEY_H },
+		{ XK_j,            KEY_J },
+		{ XK_k,            KEY_K },
+		{ XK_l,            KEY_L },
+		{ XK_semicolon,    KEY_SEMICOLON },
+		{ XK_apostrophe,   KEY_APOSTROPHE },
+		{ XK_grave,        KEY_GRAVE },
+		{ XK_Shift_L,      KEY_LEFTSHIFT },
+		{ XK_backslash,    KEY_BACKSLASH },
+		{ XK_z,            KEY_Z },
+		{ XK_x,            KEY_X },
+		{ XK_c,            KEY_C },
+		{ XK_v,            KEY_V },
+		{ XK_b,            KEY_B },
+		{ XK_n,            KEY_N },
+		{ XK_m,            KEY_M },
+		{ XK_comma,        KEY_COMMA },
+		{ XK_period,       KEY_DOT },
+		{ XK_slash,        KEY_SLASH },
+		{ XK_Shift_R,      KEY_RIGHTSHIFT },
+		{ XK_KP_Multiply,  KEY_KPASTERISK },
+		{ XK_Alt_L,        KEY_LEFTALT },
+		{ XK_space,        KEY_SPACE },
+		{ XK_Caps_Lock,    KEY_CAPSLOCK },
+		{ XK_F1,           KEY_F1 },
+		{ XK_F2,           KEY_F2 },
+		{ XK_F3,           KEY_F3 },
+		{ XK_F4,           KEY_F4 },
+		{ XK_F5,           KEY_F5 },
+		{ XK_F6,           KEY_F6 },
+		{ XK_F7,           KEY_F7 },
+		{ XK_F8,           KEY_F8 },
+		{ XK_F9,           KEY_F9 },
+		{ XK_F10,          KEY_F10 },
+		{ XK_Num_Lock,     KEY_NUMLOCK },
+		{ XK_Scroll_Lock,  KEY_SCROLLLOCK },
+		{ XK_KP_7,         KEY_KP7 },
+		{ XK_KP_8,         KEY_KP8 },
+		{ XK_KP_9,         KEY_KP9 },
+		{ XK_KP_Subtract,  KEY_KPMINUS },
+		{ XK_KP_4,         KEY_KP4 },
+		{ XK_KP_5,         KEY_KP5 },
+		{ XK_KP_6,         KEY_KP6 },
+		{ XK_KP_Add,       KEY_KPPLUS },
+		{ XK_KP_1,         KEY_KP1 },
+		{ XK_KP_2,         KEY_KP2 },
+		{ XK_KP_3,         KEY_KP3 },
+		{ XK_KP_0,         KEY_KP0 },
+		{ XK_KP_Decimal,   KEY_KPDOT },
+		{ XK_F11,          KEY_F11 },
+		{ XK_F12,          KEY_F12 },
+		{ XK_KP_Enter,     KEY_KPENTER },
+		{ XK_Control_R,    KEY_RIGHTCTRL },
+		{ XK_KP_Divide,    KEY_KPSLASH },
+		{ XK_Print,        KEY_SYSRQ },
+		{ XK_Alt_R,        KEY_RIGHTALT },
+		{ XK_Home,         KEY_HOME },
+		{ XK_Up,           KEY_UP },
+		{ XK_Prior,        KEY_PAGEUP },
+		{ XK_Left,         KEY_LEFT },
+		{ XK_Right,        KEY_RIGHT },
+		{ XK_End,          KEY_END },
+		{ XK_Down,         KEY_DOWN },
+		{ XK_Next,         KEY_PAGEDOWN },
+		{ XK_Insert,       KEY_INSERT },
+		{ XK_Delete,       KEY_DELETE },
+		{ XK_Super_L,      KEY_LEFTMETA },
+		{ XK_Super_R,      KEY_RIGHTMETA },
+		{ XK_Menu,         KEY_MENU },
+		{ XK_A,            KEY_A },
+		{ XK_B,            KEY_B },
+		{ XK_C,            KEY_C },
+		{ XK_D,            KEY_D },
+		{ XK_E,            KEY_E },
+		{ XK_F,            KEY_F },
+		{ XK_G,            KEY_G },
+		{ XK_H,            KEY_H },
+		{ XK_I,            KEY_I },
+		{ XK_J,            KEY_J },
+		{ XK_K,            KEY_K },
+		{ XK_L,            KEY_L },
+		{ XK_M,            KEY_M },
+		{ XK_N,            KEY_N },
+		{ XK_O,            KEY_O },
+		{ XK_P,            KEY_P },
+		{ XK_Q,            KEY_Q },
+		{ XK_R,            KEY_R },
+		{ XK_S,            KEY_S },
+		{ XK_T,            KEY_T },
+		{ XK_U,            KEY_U },
+		{ XK_V,            KEY_V },
+		{ XK_W,            KEY_W },
+		{ XK_X,            KEY_X },
+		{ XK_Y,            KEY_Y },
+		{ XK_Z,            KEY_Z },
+	};
+
+	for( const auto& entry : table )
 	{
-	case XK_Escape:       return KEY_ESC;
-	case XK_1:            return KEY_1;
-	case XK_2:            return KEY_2;
-	case XK_3:            return KEY_3;
-	case XK_4:            return KEY_4;
-	case XK_5:            return KEY_5;
-	case XK_6:            return KEY_6;
-	case XK_7:            return KEY_7;
-	case XK_8:            return KEY_8;
-	case XK_9:            return KEY_9;
-	case XK_0:            return KEY_0;
-	case XK_minus:        return KEY_MINUS;
-	case XK_equal:        return KEY_EQUAL;
-	case XK_BackSpace:    return KEY_BACKSPACE;
-	case XK_Tab:          return KEY_TAB;
-	case XK_q:            return KEY_Q;
-	case XK_w:            return KEY_W;
-	case XK_e:            return KEY_E;
-	case XK_r:            return KEY_R;
-	case XK_t:            return KEY_T;
-	case XK_y:            return KEY_Y;
-	case XK_u:            return KEY_U;
-	case XK_i:            return KEY_I;
-	case XK_o:            return KEY_O;
-	case XK_p:            return KEY_P;
-	case XK_bracketleft:  return KEY_LEFTBRACE;
-	case XK_bracketright: return KEY_RIGHTBRACE;
-	case XK_Return:       return KEY_ENTER;
-	case XK_Control_L:    return KEY_LEFTCTRL;
-	case XK_a:            return KEY_A;
-	case XK_s:            return KEY_S;
-	case XK_d:            return KEY_D;
-	case XK_f:            return KEY_F;
-	case XK_g:            return KEY_G;
-	case XK_h:            return KEY_H;
-	case XK_j:            return KEY_J;
-	case XK_k:            return KEY_K;
-	case XK_l:            return KEY_L;
-	case XK_semicolon:    return KEY_SEMICOLON;
-	case XK_apostrophe:   return KEY_APOSTROPHE;
-	case XK_grave:        return KEY_GRAVE;
-	case XK_Shift_L:      return KEY_LEFTSHIFT;
-	case XK_backslash:    return KEY_BACKSLASH;
-	case XK_z:            return KEY_Z;
-	case XK_x:            return KEY_X;
-	case XK_c:            return KEY_C;
-	case XK_v:            return KEY_V;
-	case XK_b:            return KEY_B;
-	case XK_n:            return KEY_N;
-	case XK_m:            return KEY_M;
-	case XK_comma:        return KEY_COMMA;
-	case XK_period:       return KEY_DOT;
-	case XK_slash:        return KEY_SLASH;
-	case XK_Shift_R:      return KEY_RIGHTSHIFT;
-	case XK_KP_Multiply:  return KEY_KPASTERISK;
-	case XK_Alt_L:        return KEY_LEFTALT;
-	case XK_space:        return KEY_SPACE;
-	case XK_Caps_Lock:    return KEY_CAPSLOCK;
-	case XK_F1:           return KEY_F1;
-	case XK_F2:           return KEY_F2;
-	case XK_F3:           return KEY_F3;
-	case XK_F4:           return KEY_F4;
-	case XK_F5:           return KEY_F5;
-	case XK_F6:           return KEY_F6;
-	case XK_F7:           return KEY_F7;
-	case XK_F8:           return KEY_F8;
-	case XK_F9:           return KEY_F9;
-	case XK_F10:          return KEY_F10;
-	case XK_Num_Lock:     return KEY_NUMLOCK;
-	case XK_Scroll_Lock:  return KEY_SCROLLLOCK;
-	case XK_KP_7:         return KEY_KP7;
-	case XK_KP_8:         return KEY_KP8;
-	case XK_KP_9:         return KEY_KP9;
-	case XK_KP_Subtract:  return KEY_KPMINUS;
-	case XK_KP_4:         return KEY_KP4;
-	case XK_KP_5:         return KEY_KP5;
-	case XK_KP_6:         return KEY_KP6;
-	case XK_KP_Add:       return KEY_KPPLUS;
-	case XK_KP_1:         return KEY_KP1;
-	case XK_KP_2:         return KEY_KP2;
-	case XK_KP_3:         return KEY_KP3;
-	case XK_KP_0:         return KEY_KP0;
-	case XK_KP_Decimal:   return KEY_KPDOT;
-	case XK_F11:          return KEY_F11;
-	case XK_F12:          return KEY_F12;
-	case XK_KP_Enter:     return KEY_KPENTER;
-	case XK_Control_R:    return KEY_RIGHTCTRL;
-	case XK_KP_Divide:    return KEY_KPSLASH;
-	case XK_Print:        return KEY_SYSRQ;
-	case XK_Alt_R:        return KEY_RIGHTALT;
-	case XK_Home:         return KEY_HOME;
-	case XK_Up:           return KEY_UP;
-	case XK_Prior:        return KEY_PAGEUP;
-	case XK_Left:         return KEY_LEFT;
-	case XK_Right:        return KEY_RIGHT;
-	case XK_End:          return KEY_END;
-	case XK_Down:         return KEY_DOWN;
-	case XK_Next:         return KEY_PAGEDOWN;
-	case XK_Insert:       return KEY_INSERT;
-	case XK_Delete:       return KEY_DELETE;
-	case XK_Super_L:      return KEY_LEFTMETA;
-	case XK_Super_R:      return KEY_RIGHTMETA;
-	case XK_Menu:         return KEY_MENU;
-	case XK_A:            return KEY_A;
-	case XK_B:            return KEY_B;
-	case XK_C:            return KEY_C;
-	case XK_D:            return KEY_D;
-	case XK_E:            return KEY_E;
-	case XK_F:            return KEY_F;
-	case XK_G:            return KEY_G;
-	case XK_H:            return KEY_H;
-	case XK_I:            return KEY_I;
-	case XK_J:            return KEY_J;
-	case XK_K:            return KEY_K;
-	case XK_L:            return KEY_L;
-	case XK_M:            return KEY_M;
-	case XK_N:            return KEY_N;
-	case XK_O:            return KEY_O;
-	case XK_P:            return KEY_P;
-	case XK_Q:            return KEY_Q;
-	case XK_R:            return KEY_R;
-	case XK_S:            return KEY_S;
-	case XK_T:            return KEY_T;
-	case XK_U:            return KEY_U;
-	case XK_V:            return KEY_V;
-	case XK_W:            return KEY_W;
-	case XK_X:            return KEY_X;
-	case XK_Y:            return KEY_Y;
-	case XK_Z:            return KEY_Z;
-	default:
-		return -1;
+		if( entry.keysym == keysym )
+		{
+			return entry.keycode;
+		}
 	}
+
+	return -1;
 }
 
 
@@ -360,74 +367,81 @@ int LinuxKeyboardInput::utf8ToLinuxKeycode( const QByteArray& utf8Data )
 		return -1;
 	}
 
-	const char c = utf8Data.at( 0 );
+	const auto c = utf8Data.at( 0 );
 
-	// digit_0 maps to KEY_0, not KEY_1 + (-1)
-	if( c >= '0' && c <= '9' )
-	{
-		constexpr int digitKeycodes[] = { 11, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-		return digitKeycodes[ c - '0' ];
-	}
-
-	// Linux keycodes for letters are NOT sequential (KEY_A=30, KEY_B=48, etc.)
-	// Must use explicit lookup instead of KEY_A + offset
-	constexpr int letterKeycodes[] = {
-		// a b c d e f g h i j k l m n o p q r s t u v w x y z
-		30,48,46,32,18,33,34,35,23,36,37,38,50,49,24,25,16,19,31,20,22,47,17,45,21,44
-		// A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
-		// same values as lowercase
-	};
-
+	// Fast path for alphanumeric ASCII
 	if( c >= 'a' && c <= 'z' )
 	{
+		static constexpr int letterKeycodes[] = {
+		// a  b  c  d  e  f  g  h  i  j  k  l  m  n  o  p  q  r  s  t  u  v  w  x  y  z
+			30,48,46,32,18,33,34,35,23,36,37,38,50,49,24,25,16,19,31,20,22,47,17,45,21,44
+		};
 		return letterKeycodes[ c - 'a' ];
 	}
 	if( c >= 'A' && c <= 'Z' )
 	{
+		static constexpr int letterKeycodes[] = {
+		// A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T  U  V  W  X  Y  Z
+			30,48,46,32,18,33,34,35,23,36,37,38,50,49,24,25,16,19,31,20,22,47,17,45,21,44
+		};
 		return letterKeycodes[ c - 'A' ];
 	}
-	if( c >= '0' && c <= '9' )
+
+	static constexpr struct { char ch; int keycode; } table[] = {
+		{ '0', KEY_0 },
+		{ '1', KEY_1 },
+		{ '2', KEY_2 },
+		{ '3', KEY_3 },
+		{ '4', KEY_4 },
+		{ '5', KEY_5 },
+		{ '6', KEY_6 },
+		{ '7', KEY_7 },
+		{ '8', KEY_8 },
+		{ '9', KEY_9 },
+		{ '!', KEY_1 },
+		{ '@', KEY_2 },
+		{ '#', KEY_3 },
+		{ '$', KEY_4 },
+		{ '%', KEY_5 },
+		{ '^', KEY_6 },
+		{ '&', KEY_7 },
+		{ '*', KEY_8 },
+		{ '(', KEY_9 },
+		{ ')', KEY_0 },
+		{ '-', KEY_MINUS },
+		{ '_', KEY_MINUS },
+		{ '=', KEY_EQUAL },
+		{ '+', KEY_EQUAL },
+		{ '[', KEY_LEFTBRACE },
+		{ '{', KEY_LEFTBRACE },
+		{ ']', KEY_RIGHTBRACE },
+		{ '}', KEY_RIGHTBRACE },
+		{ '\\', KEY_BACKSLASH },
+		{ '|', KEY_BACKSLASH },
+		{ ';', KEY_SEMICOLON },
+		{ ':', KEY_SEMICOLON },
+		{ '\'', KEY_APOSTROPHE },
+		{ '"', KEY_APOSTROPHE },
+		{ '`', KEY_GRAVE },
+		{ '~', KEY_GRAVE },
+		{ ',', KEY_COMMA },
+		{ '<', KEY_COMMA },
+		{ '.', KEY_DOT },
+		{ '>', KEY_DOT },
+		{ '/', KEY_SLASH },
+		{ '?', KEY_SLASH },
+		{ ' ', KEY_SPACE },
+		{ '\n', KEY_ENTER },
+		{ '\t', KEY_TAB },
+	};
+
+	for( const auto& entry : table )
 	{
-		return KEY_1 + ( c - '1' );
+		if( entry.ch == c )
+		{
+			return entry.keycode;
+		}
 	}
 
-	switch( c )
-	{
-	case '!': return KEY_1;
-	case '@': return KEY_2;
-	case '#': return KEY_3;
-	case '$': return KEY_4;
-	case '%': return KEY_5;
-	case '^': return KEY_6;
-	case '&': return KEY_7;
-	case '*': return KEY_8;
-	case '(': return KEY_9;
-	case ')': return KEY_0;
-	case '-': return KEY_MINUS;
-	case '_': return KEY_MINUS;
-	case '=': return KEY_EQUAL;
-	case '+': return KEY_EQUAL;
-	case '[': return KEY_LEFTBRACE;
-	case '{': return KEY_LEFTBRACE;
-	case ']': return KEY_RIGHTBRACE;
-	case '}': return KEY_RIGHTBRACE;
-	case '\\': return KEY_BACKSLASH;
-	case '|': return KEY_BACKSLASH;
-	case ';': return KEY_SEMICOLON;
-	case ':': return KEY_SEMICOLON;
-	case '\'': return KEY_APOSTROPHE;
-	case '"': return KEY_APOSTROPHE;
-	case '`': return KEY_GRAVE;
-	case '~': return KEY_GRAVE;
-	case ',': return KEY_COMMA;
-	case '<': return KEY_COMMA;
-	case '.': return KEY_DOT;
-	case '>': return KEY_DOT;
-	case '/': return KEY_SLASH;
-	case '?': return KEY_SLASH;
-	case ' ': return KEY_SPACE;
-	case '\n': return KEY_ENTER;
-	case '\t': return KEY_TAB;
-	default: return -1;
-	}
+	return -1;
 }

--- a/plugins/platform/linux/LinuxKeyboardInput.cpp
+++ b/plugins/platform/linux/LinuxKeyboardInput.cpp
@@ -23,32 +23,65 @@
  */
 
 #include <QThread>
+#include <QProcessEnvironment>
 
+#include "VeyonCore.h"
 #include "LinuxKeyboardInput.h"
 
 #include <X11/Xlib.h>
 
 #include <fakekey/fakekey.h>
 
+#include <fcntl.h>
+#include <linux/input.h>
+#include <linux/uinput.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
 
 LinuxKeyboardInput::LinuxKeyboardInput() :
-	m_display( XOpenDisplay( nullptr ) ),
-	m_fakeKeyHandle( fakekey_init( m_display ) )
+	m_isWaylandSession(qEnvironmentVariableIsSet("WAYLAND_DISPLAY"))
 {
+	if (m_isWaylandSession)
+	{
+		initUinput();
+	}
+	else
+	{
+		m_display = XOpenDisplay( nullptr );
+		m_fakeKeyHandle = fakekey_init( m_display );
+	}
 }
 
 
 
 LinuxKeyboardInput::~LinuxKeyboardInput()
 {
-	free( m_fakeKeyHandle );
-	XCloseDisplay( m_display );
+	if( m_uinputAvailable )
+	{
+		cleanupUinput();
+	}
+	else
+	{
+		free( m_fakeKeyHandle );
+		XCloseDisplay( m_display );
+	}
 }
 
 
 
 void LinuxKeyboardInput::pressAndReleaseKey( uint32_t keysym )
 {
+	if( m_uinputAvailable )
+	{
+		const auto linuxKeycode = keysymToLinuxKeycode( keysym );
+		if( linuxKeycode >= 0 )
+		{
+			pressAndReleaseKeyUinput( static_cast<uint32_t>( linuxKeycode ) );
+		}
+		return;
+	}
+
 	fakekey_press_keysym( m_fakeKeyHandle, keysym, 0 );
 	fakekey_release( m_fakeKeyHandle );
 }
@@ -57,6 +90,12 @@ void LinuxKeyboardInput::pressAndReleaseKey( uint32_t keysym )
 
 void LinuxKeyboardInput::pressAndReleaseKey( const QByteArray& utf8Data )
 {
+	if( m_uinputAvailable )
+	{
+		pressAndReleaseKeyUinputUtf8( utf8Data );
+		return;
+	}
+
 	fakekey_press( m_fakeKeyHandle, reinterpret_cast<const unsigned char *>( utf8Data.constData() ), utf8Data.size(), 0 );
 	fakekey_release( m_fakeKeyHandle );
 }
@@ -69,5 +108,324 @@ void LinuxKeyboardInput::sendString(const QString& string, int keyPressInterval)
 	{
 		pressAndReleaseKey( string.mid( i, 1 ).toUtf8() );
 		QThread::msleep(keyPressInterval);
+	}
+}
+
+
+
+void LinuxKeyboardInput::initUinput()
+{
+	m_uinputFd = ::open( "/dev/uinput", O_WRONLY | O_NONBLOCK );
+	if( m_uinputFd < 0 )
+	{
+		m_uinputFd = ::open( "/dev/input/uinput", O_WRONLY | O_NONBLOCK );
+	}
+
+	if( m_uinputFd < 0 )
+	{
+		vWarning() << "uinput not available";
+		m_uinputAvailable = false;
+		return;
+	}
+
+	::ioctl( m_uinputFd, UI_SET_EVBIT, EV_KEY );
+	::ioctl( m_uinputFd, UI_SET_EVBIT, EV_SYN );
+	for( int key = 0; key < KEY_MAX; ++key )
+	{
+		::ioctl( m_uinputFd, UI_SET_KEYBIT, key );
+	}
+
+	struct uinput_setup usetup;
+	std::memset( &usetup, 0, sizeof( usetup ) );
+	usetup.id.bustype = BUS_USB;
+	usetup.id.vendor  = 0x1d6b;
+	usetup.id.product = 0x0001;
+	std::strncpy( usetup.name, "Veyon Virtual Keyboard", sizeof( usetup.name ) - 1 );
+
+	if( ::ioctl( m_uinputFd, UI_DEV_SETUP, &usetup ) < 0 ||
+		::ioctl( m_uinputFd, UI_DEV_CREATE ) < 0 )
+	{
+		vWarning() << "uinput create failed";
+		::close( m_uinputFd );
+		m_uinputFd = -1;
+		m_uinputAvailable = false;
+		return;
+	}
+
+	m_uinputAvailable = true;
+}
+
+
+
+void LinuxKeyboardInput::cleanupUinput()
+{
+	if( m_uinputFd >= 0 )
+	{
+		::ioctl( m_uinputFd, UI_DEV_DESTROY );
+		::close( m_uinputFd );
+		m_uinputFd = -1;
+	}
+	m_uinputAvailable = false;
+}
+
+
+
+void LinuxKeyboardInput::pressAndReleaseKeyUinput( uint32_t linuxKeycode )
+{
+	if( m_uinputFd < 0 )
+	{
+		return;
+	}
+
+	struct input_event ev;
+	std::memset( &ev, 0, sizeof( ev ) );
+
+	ev.type = EV_KEY; ev.code = linuxKeycode; ev.value = 1;
+	::write( m_uinputFd, &ev, sizeof( ev ) );
+	ev.type = EV_SYN; ev.code = SYN_REPORT; ev.value = 0;
+	::write( m_uinputFd, &ev, sizeof( ev ) );
+
+	ev.type = EV_KEY; ev.code = linuxKeycode; ev.value = 0;
+	::write( m_uinputFd, &ev, sizeof( ev ) );
+	ev.type = EV_SYN; ev.code = SYN_REPORT; ev.value = 0;
+	::write( m_uinputFd, &ev, sizeof( ev ) );
+}
+
+
+
+void LinuxKeyboardInput::pressAndReleaseKeyUinputUtf8( const QByteArray& utf8Data )
+{
+	const auto linuxKeycode = utf8ToLinuxKeycode( utf8Data );
+	if( linuxKeycode >= 0 )
+	{
+		pressAndReleaseKeyUinput( static_cast<uint32_t>( linuxKeycode ) );
+	}
+}
+
+
+#define XK_LATIN1
+#define XK_MISCELLANY
+#define XK_XKB_KEYS
+#include <X11/keysymdef.h>
+
+
+int LinuxKeyboardInput::keysymToLinuxKeycode( uint32_t keysym )
+{
+	switch( keysym )
+	{
+	case XK_Escape:       return KEY_ESC;
+	case XK_1:            return KEY_1;
+	case XK_2:            return KEY_2;
+	case XK_3:            return KEY_3;
+	case XK_4:            return KEY_4;
+	case XK_5:            return KEY_5;
+	case XK_6:            return KEY_6;
+	case XK_7:            return KEY_7;
+	case XK_8:            return KEY_8;
+	case XK_9:            return KEY_9;
+	case XK_0:            return KEY_0;
+	case XK_minus:        return KEY_MINUS;
+	case XK_equal:        return KEY_EQUAL;
+	case XK_BackSpace:    return KEY_BACKSPACE;
+	case XK_Tab:          return KEY_TAB;
+	case XK_q:            return KEY_Q;
+	case XK_w:            return KEY_W;
+	case XK_e:            return KEY_E;
+	case XK_r:            return KEY_R;
+	case XK_t:            return KEY_T;
+	case XK_y:            return KEY_Y;
+	case XK_u:            return KEY_U;
+	case XK_i:            return KEY_I;
+	case XK_o:            return KEY_O;
+	case XK_p:            return KEY_P;
+	case XK_bracketleft:  return KEY_LEFTBRACE;
+	case XK_bracketright: return KEY_RIGHTBRACE;
+	case XK_Return:       return KEY_ENTER;
+	case XK_Control_L:    return KEY_LEFTCTRL;
+	case XK_a:            return KEY_A;
+	case XK_s:            return KEY_S;
+	case XK_d:            return KEY_D;
+	case XK_f:            return KEY_F;
+	case XK_g:            return KEY_G;
+	case XK_h:            return KEY_H;
+	case XK_j:            return KEY_J;
+	case XK_k:            return KEY_K;
+	case XK_l:            return KEY_L;
+	case XK_semicolon:    return KEY_SEMICOLON;
+	case XK_apostrophe:   return KEY_APOSTROPHE;
+	case XK_grave:        return KEY_GRAVE;
+	case XK_Shift_L:      return KEY_LEFTSHIFT;
+	case XK_backslash:    return KEY_BACKSLASH;
+	case XK_z:            return KEY_Z;
+	case XK_x:            return KEY_X;
+	case XK_c:            return KEY_C;
+	case XK_v:            return KEY_V;
+	case XK_b:            return KEY_B;
+	case XK_n:            return KEY_N;
+	case XK_m:            return KEY_M;
+	case XK_comma:        return KEY_COMMA;
+	case XK_period:       return KEY_DOT;
+	case XK_slash:        return KEY_SLASH;
+	case XK_Shift_R:      return KEY_RIGHTSHIFT;
+	case XK_KP_Multiply:  return KEY_KPASTERISK;
+	case XK_Alt_L:        return KEY_LEFTALT;
+	case XK_space:        return KEY_SPACE;
+	case XK_Caps_Lock:    return KEY_CAPSLOCK;
+	case XK_F1:           return KEY_F1;
+	case XK_F2:           return KEY_F2;
+	case XK_F3:           return KEY_F3;
+	case XK_F4:           return KEY_F4;
+	case XK_F5:           return KEY_F5;
+	case XK_F6:           return KEY_F6;
+	case XK_F7:           return KEY_F7;
+	case XK_F8:           return KEY_F8;
+	case XK_F9:           return KEY_F9;
+	case XK_F10:          return KEY_F10;
+	case XK_Num_Lock:     return KEY_NUMLOCK;
+	case XK_Scroll_Lock:  return KEY_SCROLLLOCK;
+	case XK_KP_7:         return KEY_KP7;
+	case XK_KP_8:         return KEY_KP8;
+	case XK_KP_9:         return KEY_KP9;
+	case XK_KP_Subtract:  return KEY_KPMINUS;
+	case XK_KP_4:         return KEY_KP4;
+	case XK_KP_5:         return KEY_KP5;
+	case XK_KP_6:         return KEY_KP6;
+	case XK_KP_Add:       return KEY_KPPLUS;
+	case XK_KP_1:         return KEY_KP1;
+	case XK_KP_2:         return KEY_KP2;
+	case XK_KP_3:         return KEY_KP3;
+	case XK_KP_0:         return KEY_KP0;
+	case XK_KP_Decimal:   return KEY_KPDOT;
+	case XK_F11:          return KEY_F11;
+	case XK_F12:          return KEY_F12;
+	case XK_KP_Enter:     return KEY_KPENTER;
+	case XK_Control_R:    return KEY_RIGHTCTRL;
+	case XK_KP_Divide:    return KEY_KPSLASH;
+	case XK_Print:        return KEY_SYSRQ;
+	case XK_Alt_R:        return KEY_RIGHTALT;
+	case XK_Home:         return KEY_HOME;
+	case XK_Up:           return KEY_UP;
+	case XK_Prior:        return KEY_PAGEUP;
+	case XK_Left:         return KEY_LEFT;
+	case XK_Right:        return KEY_RIGHT;
+	case XK_End:          return KEY_END;
+	case XK_Down:         return KEY_DOWN;
+	case XK_Next:         return KEY_PAGEDOWN;
+	case XK_Insert:       return KEY_INSERT;
+	case XK_Delete:       return KEY_DELETE;
+	case XK_Super_L:      return KEY_LEFTMETA;
+	case XK_Super_R:      return KEY_RIGHTMETA;
+	case XK_Menu:         return KEY_MENU;
+	case XK_A:            return KEY_A;
+	case XK_B:            return KEY_B;
+	case XK_C:            return KEY_C;
+	case XK_D:            return KEY_D;
+	case XK_E:            return KEY_E;
+	case XK_F:            return KEY_F;
+	case XK_G:            return KEY_G;
+	case XK_H:            return KEY_H;
+	case XK_I:            return KEY_I;
+	case XK_J:            return KEY_J;
+	case XK_K:            return KEY_K;
+	case XK_L:            return KEY_L;
+	case XK_M:            return KEY_M;
+	case XK_N:            return KEY_N;
+	case XK_O:            return KEY_O;
+	case XK_P:            return KEY_P;
+	case XK_Q:            return KEY_Q;
+	case XK_R:            return KEY_R;
+	case XK_S:            return KEY_S;
+	case XK_T:            return KEY_T;
+	case XK_U:            return KEY_U;
+	case XK_V:            return KEY_V;
+	case XK_W:            return KEY_W;
+	case XK_X:            return KEY_X;
+	case XK_Y:            return KEY_Y;
+	case XK_Z:            return KEY_Z;
+	default:
+		return -1;
+	}
+}
+
+
+
+
+
+int LinuxKeyboardInput::utf8ToLinuxKeycode( const QByteArray& utf8Data )
+{
+	if( utf8Data.size() != 1 )
+	{
+		return -1;
+	}
+
+	const char c = utf8Data.at( 0 );
+
+	// digit_0 maps to KEY_0, not KEY_1 + (-1)
+	if( c >= '0' && c <= '9' )
+	{
+		constexpr int digitKeycodes[] = { 11, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+		return digitKeycodes[ c - '0' ];
+	}
+
+	// Linux keycodes for letters are NOT sequential (KEY_A=30, KEY_B=48, etc.)
+	// Must use explicit lookup instead of KEY_A + offset
+	constexpr int letterKeycodes[] = {
+		// a b c d e f g h i j k l m n o p q r s t u v w x y z
+		30,48,46,32,18,33,34,35,23,36,37,38,50,49,24,25,16,19,31,20,22,47,17,45,21,44
+		// A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+		// same values as lowercase
+	};
+
+	if( c >= 'a' && c <= 'z' )
+	{
+		return letterKeycodes[ c - 'a' ];
+	}
+	if( c >= 'A' && c <= 'Z' )
+	{
+		return letterKeycodes[ c - 'A' ];
+	}
+	if( c >= '0' && c <= '9' )
+	{
+		return KEY_1 + ( c - '1' );
+	}
+
+	switch( c )
+	{
+	case '!': return KEY_1;
+	case '@': return KEY_2;
+	case '#': return KEY_3;
+	case '$': return KEY_4;
+	case '%': return KEY_5;
+	case '^': return KEY_6;
+	case '&': return KEY_7;
+	case '*': return KEY_8;
+	case '(': return KEY_9;
+	case ')': return KEY_0;
+	case '-': return KEY_MINUS;
+	case '_': return KEY_MINUS;
+	case '=': return KEY_EQUAL;
+	case '+': return KEY_EQUAL;
+	case '[': return KEY_LEFTBRACE;
+	case '{': return KEY_LEFTBRACE;
+	case ']': return KEY_RIGHTBRACE;
+	case '}': return KEY_RIGHTBRACE;
+	case '\\': return KEY_BACKSLASH;
+	case '|': return KEY_BACKSLASH;
+	case ';': return KEY_SEMICOLON;
+	case ':': return KEY_SEMICOLON;
+	case '\'': return KEY_APOSTROPHE;
+	case '"': return KEY_APOSTROPHE;
+	case '`': return KEY_GRAVE;
+	case '~': return KEY_GRAVE;
+	case ',': return KEY_COMMA;
+	case '<': return KEY_COMMA;
+	case '.': return KEY_DOT;
+	case '>': return KEY_DOT;
+	case '/': return KEY_SLASH;
+	case '?': return KEY_SLASH;
+	case ' ': return KEY_SPACE;
+	case '\n': return KEY_ENTER;
+	case '\t': return KEY_TAB;
+	default: return -1;
 	}
 }

--- a/plugins/platform/linux/LinuxKeyboardInput.cpp
+++ b/plugins/platform/linux/LinuxKeyboardInput.cpp
@@ -28,6 +28,8 @@
 #include "VeyonCore.h"
 #include "LinuxKeyboardInput.h"
 
+#include <cstring>
+
 #include <X11/Xlib.h>
 
 #include <fakekey/fakekey.h>

--- a/plugins/platform/linux/LinuxKeyboardInput.h
+++ b/plugins/platform/linux/LinuxKeyboardInput.h
@@ -44,7 +44,21 @@ public:
 	void sendString(const QString& string, int keyPressInterval);
 
 private:
-	Display* m_display;
-	FakeKey* m_fakeKeyHandle;
+	// X11/libfakekey path
+	Display* m_display{nullptr};
+	FakeKey* m_fakeKeyHandle{nullptr};
+
+	// Wayland/uinput path
+	int m_uinputFd{-1};
+	bool m_uinputAvailable{false};
+	const bool m_isWaylandSession;
+
+	void initUinput();
+	void cleanupUinput();
+	void pressAndReleaseKeyUinput(uint32_t linuxKeycode);
+	void pressAndReleaseKeyUinputUtf8(const QByteArray& utf8Data);
+
+	static int keysymToLinuxKeycode(uint32_t keysym);
+	static int utf8ToLinuxKeycode(const QByteArray& utf8Data);
 
 };

--- a/plugins/platform/linux/LinuxServerProcess.cpp
+++ b/plugins/platform/linux/LinuxServerProcess.cpp
@@ -36,6 +36,7 @@
 #include "Filesystem.h"
 #include "LinuxCoreFunctions.h"
 #include "LinuxServerProcess.h"
+#include "LinuxUserFunctions.h"
 #include "VeyonConfiguration.h"
 
 
@@ -81,6 +82,24 @@ void LinuxServerProcess::start()
 	}
 	else if (m_sessionType == LinuxSessionFunctions::Type::Wayland)
 	{
+		const auto sessionUserPath = LinuxSessionFunctions::getSessionUser(m_sessionPath);
+		const auto sessionUserName = LinuxUserFunctions::getUserProperty(sessionUserPath, QStringLiteral("Name")).toString();
+		if (sessionUserName.isEmpty())
+		{
+			vCritical() << "failed to determine user name of session user" << sessionUserPath;
+		}
+
+		m_sessionUserId = LinuxUserFunctions::userIdFromName(sessionUserName);
+
+		if (m_sessionUserId == LinuxUserFunctions::InvalidUserId)
+		{
+			vCritical() << "failed to determine user ID of user" << sessionUserName;
+		}
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		setChildProcessModifier([this] { setProcessUserId(); });
+#endif
+
 		const auto desktopEnvironment = LinuxSessionFunctions::getSessionDesktopEnvironment(m_sessionPath);
 		const auto desktopFile = VeyonCore::applicationsDirectory() + QDir::separator() + QStringLiteral("io.veyon.veyon-server.desktop");
 		switch (desktopEnvironment)
@@ -162,5 +181,15 @@ void LinuxServerProcess::stop()
 			sendSignalRecursively( pid, SIGKILL );
 			LinuxCoreFunctions::waitForProcess( pid, ServerKillTimeout, ServerWaitSleepInterval );
 		}
+	}
+}
+
+
+
+void LinuxServerProcess::setProcessUserId()
+{
+	if (m_sessionUserId != LinuxUserFunctions::InvalidUserId)
+	{
+		setuid(m_sessionUserId);
 	}
 }

--- a/plugins/platform/linux/LinuxServerProcess.cpp
+++ b/plugins/platform/linux/LinuxServerProcess.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include <QDir>
 #include <QFileInfo>
 
 #include <csignal>
@@ -38,11 +39,14 @@
 #include "VeyonConfiguration.h"
 
 
-LinuxServerProcess::LinuxServerProcess( const QProcessEnvironment& processEnvironment,
-										const QString& sessionPath, int sessionId, QObject* parent ) :
-	QProcess( parent ),
-	m_sessionPath( sessionPath ),
-	m_sessionId( sessionId )
+LinuxServerProcess::LinuxServerProcess(const QProcessEnvironment& processEnvironment,
+									   const QString& sessionPath, int sessionId,
+									   LinuxSessionFunctions::Type sessionType,
+									   QObject* parent) :
+	QProcess(parent),
+	m_sessionPath(sessionPath),
+	m_sessionId(sessionId),
+	m_sessionType(sessionType)
 {
 	setProcessEnvironment( processEnvironment );
 }
@@ -74,6 +78,24 @@ void LinuxServerProcess::start()
 	else if( VeyonCore::isDebugging() && QFileInfo::exists( catchsegv ) )
 	{
 		QProcess::start( catchsegv, { VeyonCore::filesystem().serverFilePath() } );
+	}
+	else if (m_sessionType == LinuxSessionFunctions::Type::Wayland)
+	{
+		const auto desktopEnvironment = LinuxSessionFunctions::getSessionDesktopEnvironment(m_sessionPath);
+		const auto desktopFile = VeyonCore::applicationsDirectory() + QDir::separator() + QStringLiteral("io.veyon.veyon-server.desktop");
+		switch (desktopEnvironment)
+		{
+		case LinuxSessionFunctions::DesktopEnvironment::KDE:
+			QProcess::start(QStringLiteral("kioclient"), {QStringLiteral("exec"), desktopFile});
+			break;
+		case LinuxSessionFunctions::DesktopEnvironment::GNOME:
+			QProcess::start(QStringLiteral("gio"), {QStringLiteral("launch"), desktopFile});
+			break;
+		default:
+			vWarning() << "Unsupported desktop environment with Wayland session, launching server directly";
+			QProcess::start(VeyonCore::filesystem().serverFilePath(), QStringList{});
+			break;
+		}
 	}
 	else
 	{

--- a/plugins/platform/linux/LinuxServerProcess.cpp
+++ b/plugins/platform/linux/LinuxServerProcess.cpp
@@ -22,16 +22,20 @@
  *
  */
 
+#include <QDBusConnectionInterface>
 #include <QDir>
 #include <QFileInfo>
 
 #include <csignal>
+#include <grp.h>
+#include <pwd.h>
 #ifdef HAVE_LIBPROCPS
 #include <proc/readproc.h>
 #endif
 #include <sys/errno.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 #include "Filesystem.h"
 #include "LinuxCoreFunctions.h"
@@ -100,20 +104,37 @@ void LinuxServerProcess::start()
 		setChildProcessModifier([this] { setProcessUserId(); });
 #endif
 
-		const auto desktopEnvironment = LinuxSessionFunctions::getSessionDesktopEnvironment(m_sessionPath);
-		const auto desktopFile = VeyonCore::applicationsDirectory() + QDir::separator() + QStringLiteral("io.veyon.veyon-server.desktop");
-		switch (desktopEnvironment)
+		// Check for xdg-desktop-portal >= 1.20 via the presence of the
+		// org.freedesktop.host.portal.Registry D-Bus service. When available,
+		// launch veyon-server directly which inherits the full session
+		// environment (DBUS_SESSION_BUS_ADDRESS, WAYLAND_DISPLAY, XDG_RUNTIME_DIR)
+		// captured from the session leader. On older portal versions fall back
+		// to kioclient/gio D-Bus activation.
+		const auto portalRegistryService = QStringLiteral("org.freedesktop.host.portal.Registry");
+		if(QDBusConnection::sessionBus().interface()->isServiceRegistered(portalRegistryService))
 		{
-		case LinuxSessionFunctions::DesktopEnvironment::KDE:
-			QProcess::start(QStringLiteral("kioclient"), {QStringLiteral("exec"), desktopFile});
-			break;
-		case LinuxSessionFunctions::DesktopEnvironment::GNOME:
-			QProcess::start(QStringLiteral("gio"), {QStringLiteral("launch"), desktopFile});
-			break;
-		default:
-			vWarning() << "Unsupported desktop environment with Wayland session, launching server directly";
+			vDebug() << "xdg-desktop-portal >= 1.20 detected, launching server directly";
 			QProcess::start(VeyonCore::filesystem().serverFilePath(), QStringList{});
-			break;
+		}
+		else
+		{
+			vDebug() << "xdg-desktop-portal < 1.20, falling back to D-Bus activation";
+			const auto desktopEnvironment = LinuxSessionFunctions::getSessionDesktopEnvironment(m_sessionPath);
+			const auto desktopFile = VeyonCore::applicationsDirectory() + QDir::separator()
+									 + QStringLiteral("io.veyon.veyon-server.desktop");
+			switch(desktopEnvironment)
+			{
+			case LinuxSessionFunctions::DesktopEnvironment::KDE:
+				QProcess::start(QStringLiteral("kioclient"), {QStringLiteral("exec"), desktopFile});
+				break;
+			case LinuxSessionFunctions::DesktopEnvironment::GNOME:
+				QProcess::start(QStringLiteral("gio"), {QStringLiteral("launch"), desktopFile});
+				break;
+			default:
+				vWarning() << "Unsupported desktop environment with Wayland session, launching server directly";
+				QProcess::start(VeyonCore::filesystem().serverFilePath(), QStringList{});
+				break;
+			}
 		}
 	}
 	else
@@ -190,6 +211,16 @@ void LinuxServerProcess::setProcessUserId()
 {
 	if (m_sessionUserId != LinuxUserFunctions::InvalidUserId)
 	{
-		setuid(m_sessionUserId);
+		// Look up the user's full credential data before dropping privileges
+		const auto pw_entry = getpwuid( m_sessionUserId );
+		if( pw_entry != nullptr )
+		{
+			// Set supplementary groups first (needs EUID=root)
+			initgroups( pw_entry->pw_name, pw_entry->pw_gid );
+			// Set primary group GID
+			setgid( pw_entry->pw_gid );
+		}
+		// Set UID last — after this the process has no more root privileges
+		setuid( m_sessionUserId );
 	}
 }

--- a/plugins/platform/linux/LinuxServerProcess.h
+++ b/plugins/platform/linux/LinuxServerProcess.h
@@ -26,15 +26,18 @@
 
 #include <QProcess>
 
+#include "LinuxSessionFunctions.h"
+
 // clazy:excludeall=copyable-polymorphic
 
 class LinuxServerProcess : public QProcess
 {
 	Q_OBJECT
 public:
-	explicit LinuxServerProcess( const QProcessEnvironment& processEnvironment,
-								 const QString& sessionPath, int sessionId,
-								 QObject* parent = nullptr );
+	explicit LinuxServerProcess(const QProcessEnvironment& processEnvironment,
+								const QString& sessionPath, int sessionId,
+								LinuxSessionFunctions::Type sessionType,
+								QObject* parent = nullptr);
 	~LinuxServerProcess() override;
 
 	void start();
@@ -48,4 +51,6 @@ private:
 
 	const QString m_sessionPath;
 	int m_sessionId;
+	const LinuxSessionFunctions::Type m_sessionType;
+
 };

--- a/plugins/platform/linux/LinuxServerProcess.h
+++ b/plugins/platform/linux/LinuxServerProcess.h
@@ -50,7 +50,10 @@ private:
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 	void setupChildProcess() override
 	{
-		setProcessUserId();
+		if (m_sessionType == LinuxSessionFunctions::Type::Wayland)
+		{
+			setProcessUserId();
+		}
 	}
 #endif
 

--- a/plugins/platform/linux/LinuxServerProcess.h
+++ b/plugins/platform/linux/LinuxServerProcess.h
@@ -27,6 +27,7 @@
 #include <QProcess>
 
 #include "LinuxSessionFunctions.h"
+#include "LinuxUserFunctions.h"
 
 // clazy:excludeall=copyable-polymorphic
 
@@ -44,6 +45,15 @@ public:
 	void stop();
 
 private:
+	void setProcessUserId();
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+	void setupChildProcess() override
+	{
+		setProcessUserId();
+	}
+#endif
+
 	static constexpr auto ServerShutdownTimeout = 1000;
 	static constexpr auto ServerTerminateTimeout = 3000;
 	static constexpr auto ServerKillTimeout = 3000;
@@ -52,5 +62,6 @@ private:
 	const QString m_sessionPath;
 	int m_sessionId;
 	const LinuxSessionFunctions::Type m_sessionType;
+	LinuxUserFunctions::UserId m_sessionUserId{LinuxUserFunctions::InvalidUserId};
 
 };

--- a/plugins/platform/linux/LinuxServiceCore.cpp
+++ b/plugins/platform/linux/LinuxServiceCore.cpp
@@ -243,7 +243,7 @@ void LinuxServiceCore::startServer( const QString& sessionPath )
 	sessionEnvironment.insert( QLatin1String( ServiceDataManager::serviceDataTokenEnvironmentVariable() ),
 							   QString::fromUtf8( m_dataManager.token().toByteArray() ) );
 
-	auto serverProcess = new LinuxServerProcess( sessionEnvironment, sessionPath, sessionId, this );
+	auto serverProcess = new LinuxServerProcess(sessionEnvironment, sessionPath, sessionId, sessionType, this);
 	serverProcess->start();
 
 	connect(serverProcess, &QProcess::stateChanged, this, [=, this]() { checkSessionState(sessionPath); });

--- a/plugins/platform/linux/LinuxServiceCore.cpp
+++ b/plugins/platform/linux/LinuxServiceCore.cpp
@@ -222,7 +222,8 @@ void LinuxServiceCore::startServer( const QString& sessionPath )
 
 	// workaround for #817 where LinuxSessionFunctions::getSessionEnvironment() does not return all
 	// environment variables when executed via systemd for an established KDE session and xdg-open fails
-	if (sessionEnvironment.value(LinuxSessionFunctions::xdgCurrentDesktopEnvVarName()) == QLatin1String("KDE") &&
+	if (sessionType != LinuxSessionFunctions::Type::Wayland &&
+		sessionEnvironment.value(LinuxSessionFunctions::xdgCurrentDesktopEnvVarName()) == QLatin1String("KDE") &&
 		sessionEnvironment.contains(LinuxSessionFunctions::kdeSessionVersionEnvVarName()) == false)
 	{
 		sessionEnvironment.insert(LinuxSessionFunctions::xdgCurrentDesktopEnvVarName(), QStringLiteral("X-Generic"));

--- a/plugins/platform/linux/LinuxServiceCore.cpp
+++ b/plugins/platform/linux/LinuxServiceCore.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <QDBusReply>
+#include <QDir>
 #include <QEventLoop>
 #include <QFileInfo>
 #include <QTimer>
@@ -31,6 +32,7 @@
 #include "LinuxServerProcess.h"
 #include "LinuxServiceCore.h"
 #include "LinuxSessionFunctions.h"
+#include "LinuxUserFunctions.h"
 #include "VeyonConfiguration.h"
 
 
@@ -227,6 +229,62 @@ void LinuxServiceCore::startServer( const QString& sessionPath )
 		sessionEnvironment.contains(LinuxSessionFunctions::kdeSessionVersionEnvVarName()) == false)
 	{
 		sessionEnvironment.insert(LinuxSessionFunctions::xdgCurrentDesktopEnvVarName(), QStringLiteral("X-Generic"));
+	}
+
+	// Wayland: inject critical environment variables from well-known paths
+	// if they were not captured from the session leader's process tree.
+	// This ensures DBUS_SESSION_BUS_ADDRESS, XDG_RUNTIME_DIR and
+	// WAYLAND_DISPLAY are always available for the portal-based screen
+	// capture even if /proc/<pid>/environ could not provide them.
+	if (sessionType == LinuxSessionFunctions::Type::Wayland)
+	{
+		const auto sessionUserPath = LinuxSessionFunctions::getSessionUser(sessionPath);
+		if (sessionUserPath.isEmpty() == false)
+		{
+			const auto uid = LinuxUserFunctions::getUserProperty(
+				sessionUserPath, QStringLiteral("UID")).toUInt();
+
+			if (uid > 0)
+			{
+				if (sessionEnvironment.contains(QStringLiteral("DBUS_SESSION_BUS_ADDRESS")) == false)
+				{
+					sessionEnvironment.insert(QStringLiteral("DBUS_SESSION_BUS_ADDRESS"),
+											  QStringLiteral("unix:path=/run/user/%1/bus").arg(uid));
+					vDebug() << "Wayland: injected DBUS_SESSION_BUS_ADDRESS from known path";
+				}
+
+				if (sessionEnvironment.contains(QStringLiteral("XDG_RUNTIME_DIR")) == false)
+				{
+					sessionEnvironment.insert(QStringLiteral("XDG_RUNTIME_DIR"),
+											  QStringLiteral("/run/user/%1").arg(uid));
+				}
+
+				if (sessionEnvironment.contains(QStringLiteral("WAYLAND_DISPLAY")) == false)
+				{
+					QDir dir(QStringLiteral("/run/user/%1").arg(uid));
+					const auto sockets = dir.entryList({QStringLiteral("wayland-*")}, QDir::System);
+					if (sockets.isEmpty() == false)
+					{
+						sessionEnvironment.insert(QStringLiteral("WAYLAND_DISPLAY"), sockets.first());
+					}
+				}
+			}
+		}
+
+		// Warn about any remaining missing critical variables
+		static const QStringList criticalVars = {
+			QStringLiteral("DBUS_SESSION_BUS_ADDRESS"),
+			QStringLiteral("WAYLAND_DISPLAY"),
+			QStringLiteral("XDG_RUNTIME_DIR"),
+		};
+		for (const auto& var : criticalVars)
+		{
+			if (sessionEnvironment.contains(var) == false)
+			{
+				vWarning() << "Wayland session:" << var
+						   << "not available - Portal/RemoteDesktop screen capture may not work";
+			}
+		}
 	}
 
 	const auto sessionId = m_sessionManager.openSession( sessionPath );

--- a/plugins/platform/linux/LinuxServiceCore.cpp
+++ b/plugins/platform/linux/LinuxServiceCore.cpp
@@ -144,12 +144,6 @@ void LinuxServiceCore::startServer( const QString& sessionPath )
 {
 	const auto sessionType = LinuxSessionFunctions::getSessionType( sessionPath );
 
-	if( sessionType == LinuxSessionFunctions::Type::Wayland )
-	{
-		vWarning() << "Wayland session detected but trying to start Veyon Server anyway, even though Veyon Server does "
-					  "not supported Wayland sessions. If you encounter problems, please switch to X11-based sessions!";
-	}
-
 	// do not start server for non-graphical sessions
 	if( sessionType == LinuxSessionFunctions::Type::TTY )
 	{

--- a/plugins/platform/linux/LinuxSessionFunctions.cpp
+++ b/plugins/platform/linux/LinuxSessionFunctions.cpp
@@ -25,7 +25,6 @@
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDBusReply>
-#include <QFile>
 #include <QHostInfo>
 #include <QProcessEnvironment>
 #include <QSettings>
@@ -389,28 +388,6 @@ LinuxSessionFunctions::LoginDBusSessionSeat LinuxSessionFunctions::getSessionSea
 QProcessEnvironment LinuxSessionFunctions::getSessionEnvironment( int sessionLeaderPid )
 {
 	QProcessEnvironment sessionEnv;
-
-	// Read environment of the session leader itself (e.g. systemd --user).
-	// This provides variables set by pam_systemd such as XDG_RUNTIME_DIR,
-	// XDG_SESSION_TYPE, HOME and USER.
-	QFile leaderEnvFile( QStringLiteral( "/proc/%1/environ" ).arg( sessionLeaderPid ) );
-	if( leaderEnvFile.open( QIODevice::ReadOnly ) )
-	{
-		const auto leaderEnvData = leaderEnvFile.readAll();
-		for( const auto& entry : leaderEnvData.split( '\0' ) )
-		{
-			if( entry.isEmpty() )
-			{
-				continue;
-			}
-			const auto env = QString::fromUtf8( entry );
-			const auto separatorPos = env.indexOf( QLatin1Char( '=' ) );
-			if( separatorPos > 0 )
-			{
-				sessionEnv.insert( env.left( separatorPos ), env.mid( separatorPos + 1 ) );
-			}
-		}
-	}
 
 #ifdef HAVE_LIBPROCPS
 	LinuxCoreFunctions::forEachChildProcess(

--- a/plugins/platform/linux/LinuxSessionFunctions.cpp
+++ b/plugins/platform/linux/LinuxSessionFunctions.cpp
@@ -25,6 +25,7 @@
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDBusReply>
+#include <QFile>
 #include <QHostInfo>
 #include <QProcessEnvironment>
 #include <QSettings>
@@ -388,6 +389,28 @@ LinuxSessionFunctions::LoginDBusSessionSeat LinuxSessionFunctions::getSessionSea
 QProcessEnvironment LinuxSessionFunctions::getSessionEnvironment( int sessionLeaderPid )
 {
 	QProcessEnvironment sessionEnv;
+
+	// Read environment of the session leader itself (e.g. systemd --user).
+	// This provides variables set by pam_systemd such as XDG_RUNTIME_DIR,
+	// XDG_SESSION_TYPE, HOME and USER.
+	QFile leaderEnvFile( QStringLiteral( "/proc/%1/environ" ).arg( sessionLeaderPid ) );
+	if( leaderEnvFile.open( QIODevice::ReadOnly ) )
+	{
+		const auto leaderEnvData = leaderEnvFile.readAll();
+		for( const auto& entry : leaderEnvData.split( '\0' ) )
+		{
+			if( entry.isEmpty() )
+			{
+				continue;
+			}
+			const auto env = QString::fromUtf8( entry );
+			const auto separatorPos = env.indexOf( QLatin1Char( '=' ) );
+			if( separatorPos > 0 )
+			{
+				sessionEnv.insert( env.left( separatorPos ), env.mid( separatorPos + 1 ) );
+			}
+		}
+	}
 
 #ifdef HAVE_LIBPROCPS
 	LinuxCoreFunctions::forEachChildProcess(

--- a/plugins/vncserver/CMakeLists.txt
+++ b/plugins/vncserver/CMakeLists.txt
@@ -4,6 +4,7 @@ endif()
 
 if(VEYON_BUILD_LINUX)
 	add_subdirectory(x11vnc-builtin)
+	add_subdirectory(pipewire)
 endif()
 
 add_subdirectory(external)

--- a/plugins/vncserver/pipewire/CMakeLists.txt
+++ b/plugins/vncserver/pipewire/CMakeLists.txt
@@ -1,0 +1,56 @@
+include(BuildVeyonPlugin)
+
+find_package(PipeWire)
+find_package(Qt${QT_MAJOR_VERSION} COMPONENTS DBus)
+
+get_property(HAVE_LIBVNCCLIENT GLOBAL PROPERTY HAVE_LIBVNCCLIENT)
+if(HAVE_LIBVNCCLIENT)
+	find_package(LibVNCServer 0.9.8)
+endif()
+
+if(PipeWire_FOUND AND Qt${QT_MAJOR_VERSION}DBus_FOUND AND LibVNCServer_FOUND)
+
+	qt_add_dbus_interface(DBUS_GENERATED_SOURCES
+		dbus/org.freedesktop.portal.RemoteDesktop.xml
+		OrgFreedesktopPortalRemoteDesktop
+	)
+	qt_add_dbus_interface(DBUS_GENERATED_SOURCES
+		dbus/org.freedesktop.portal.ScreenCast.xml
+		OrgFreedesktopPortalScreenCast
+	)
+	qt_add_dbus_interface(DBUS_GENERATED_SOURCES
+		dbus/org.freedesktop.portal.Request.xml
+		OrgFreedesktopPortalRequest
+	)
+	qt_add_dbus_interface(DBUS_GENERATED_SOURCES
+		dbus/org.freedesktop.portal.Session.xml
+		OrgFreedesktopPortalSession
+	)
+
+	build_veyon_plugin(pipewire-vnc-server
+		NAME PipeWireVncServer
+		SOURCES
+		PipeWireVncServer.cpp
+		PipeWireVncServer.h
+		PipeWireFramebuffer.cpp
+		PipeWireFramebuffer.h
+		PortalSession.cpp
+		PortalSession.h
+		${DBUS_GENERATED_SOURCES}
+	)
+
+	target_link_libraries(pipewire-vnc-server
+		PRIVATE
+			PipeWire::PipeWire
+			Qt${QT_MAJOR_VERSION}::DBus
+			LibVNC::LibVNCServer
+	)
+
+	target_compile_options(pipewire-vnc-server PRIVATE -Wno-parentheses)
+
+	install(
+		PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/veyon-preauth-kde.sh"
+		DESTINATION "${CMAKE_INSTALL_DATADIR}/veyon"
+		COMPONENT pipewire-vnc-server
+	)
+endif()

--- a/plugins/vncserver/pipewire/CMakeLists.txt
+++ b/plugins/vncserver/pipewire/CMakeLists.txt
@@ -3,12 +3,7 @@ include(BuildVeyonPlugin)
 find_package(PipeWire)
 find_package(Qt${QT_MAJOR_VERSION} COMPONENTS DBus)
 
-get_property(HAVE_LIBVNCCLIENT GLOBAL PROPERTY HAVE_LIBVNCCLIENT)
-if(HAVE_LIBVNCCLIENT)
-	find_package(LibVNCServer 0.9.8)
-endif()
-
-if(PipeWire_FOUND AND Qt${QT_MAJOR_VERSION}DBus_FOUND AND LibVNCServer_FOUND)
+if(PipeWire_FOUND AND Qt${QT_MAJOR_VERSION}DBus_FOUND)
 
 	qt_add_dbus_interface(DBUS_GENERATED_SOURCES
 		dbus/org.freedesktop.portal.RemoteDesktop.xml
@@ -39,12 +34,16 @@ if(PipeWire_FOUND AND Qt${QT_MAJOR_VERSION}DBus_FOUND AND LibVNCServer_FOUND)
 		${DBUS_GENERATED_SOURCES}
 	)
 
-	target_link_libraries(pipewire-vnc-server
-		PRIVATE
-			PipeWire::PipeWire
-			Qt${QT_MAJOR_VERSION}::DBus
-			LibVNC::LibVNCServer
+	target_link_libraries(pipewire-vnc-server PRIVATE
+		PipeWire::PipeWire
+		Qt${QT_MAJOR_VERSION}::DBus
 	)
+
+	if(WITH_BUNDLED_LIBVNC)
+		target_link_libraries(pipewire-vnc-server PRIVATE vncserver)
+	else()
+		target_link_libraries(pipewire-vnc-server PRIVATE LibVNC::LibVNCServer)
+	endif()
 
 	target_compile_options(pipewire-vnc-server PRIVATE -Wno-parentheses)
 

--- a/plugins/vncserver/pipewire/PipeWireFramebuffer.cpp
+++ b/plugins/vncserver/pipewire/PipeWireFramebuffer.cpp
@@ -1,0 +1,422 @@
+/*
+ * PipeWireFramebuffer.cpp - PipeWire stream consumer that fills an rfbScreen framebuffer
+ *
+ * Copyright (c) 2024-2026 Tobias Junghans <tobydox@veyon.io>
+ *
+ * This file is part of Veyon - https://veyon.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+#include "PipeWireFramebuffer.h"
+
+#include "VeyonCore.h"
+
+#include <cstring>
+
+extern "C" {
+#include <spa/buffer/meta.h>
+#include <spa/pod/builder.h>
+}
+
+PipeWireFramebuffer::PipeWireFramebuffer(QObject* parent)
+	: QObject(parent)
+{
+}
+
+PipeWireFramebuffer::~PipeWireFramebuffer()
+{
+	close();
+}
+
+bool PipeWireFramebuffer::open(int fd, quint32 nodeId, rfbScreenInfoPtr screen)
+{
+	m_rfbScreen = screen;
+	m_frameSize = {};
+
+	pw_init(nullptr, nullptr);
+
+	m_loop = pw_main_loop_new(nullptr);
+	if (!m_loop)
+	{
+		vCritical() << "Failed to create PipeWire main loop";
+		return false;
+	}
+
+	m_context = pw_context_new(pw_main_loop_get_loop(m_loop), nullptr, 0);
+	if (!m_context)
+	{
+		vCritical() << "Failed to create PipeWire context";
+		pw_main_loop_destroy(m_loop);
+		m_loop = nullptr;
+		return false;
+	}
+
+	// pw_context_connect_fd takes ownership of the fd
+	m_core = pw_context_connect_fd(m_context, fd, nullptr, 0);
+	if (!m_core)
+	{
+		vCritical() << "Failed to connect PipeWire context via FD";
+		pw_context_destroy(m_context);
+		m_context = nullptr;
+		pw_main_loop_destroy(m_loop);
+		m_loop = nullptr;
+		return false;
+	}
+
+	static const pw_core_events coreEvents = {
+		.version = PW_VERSION_CORE_EVENTS,
+		.error = &PipeWireFramebuffer::onCoreError,
+	};
+	pw_core_add_listener(m_core, &m_coreListener, &coreEvents, this);
+
+	pw_properties* props = pw_properties_new(
+		PW_KEY_MEDIA_TYPE, "Video",
+		PW_KEY_MEDIA_CATEGORY, "Capture",
+		PW_KEY_MEDIA_ROLE, "Screen",
+		nullptr
+	);
+
+	m_stream = pw_stream_new(m_core, "veyon-screen-capture", props);
+	if (!m_stream)
+	{
+		vCritical() << "Failed to create PipeWire stream";
+		spa_hook_remove(&m_coreListener);
+		pw_core_disconnect(m_core);
+		m_core = nullptr;
+		pw_context_destroy(m_context);
+		m_context = nullptr;
+		pw_main_loop_destroy(m_loop);
+		m_loop = nullptr;
+		return false;
+	}
+
+	static const pw_stream_events streamEvents = {
+		.version = PW_VERSION_STREAM_EVENTS,
+		.state_changed = &PipeWireFramebuffer::onStreamStateChanged,
+		.param_changed = &PipeWireFramebuffer::onStreamParamChanged,
+		.process = &PipeWireFramebuffer::onStreamProcess,
+	};
+	pw_stream_add_listener(m_stream, &m_streamListener, &streamEvents, this);
+
+	// Negotiate BGRx format (4 bytes/pixel, no alpha, matches rfbScreen 32-bit layout)
+	static constexpr int ParamBufSize = 1024;
+	uint8_t paramBuffer[ParamBufSize];
+	spa_pod_builder builder;
+	spa_pod_builder_init(&builder, paramBuffer, sizeof(paramBuffer));
+
+	spa_video_info_raw videoInfo{};
+	videoInfo.format = SPA_VIDEO_FORMAT_BGRx;
+
+	const spa_pod* params[1];
+	params[0] = spa_format_video_raw_build(&builder, SPA_PARAM_EnumFormat, &videoInfo);
+
+	const auto flags = static_cast<pw_stream_flags>(
+		PW_STREAM_FLAG_AUTOCONNECT | PW_STREAM_FLAG_MAP_BUFFERS
+	);
+
+	const int ret = pw_stream_connect(
+		m_stream,
+		PW_DIRECTION_INPUT,
+		nodeId,
+		flags,
+		params, 1
+	);
+
+	if (ret < 0)
+	{
+		vCritical() << "pw_stream_connect failed:" << ret;
+		spa_hook_remove(&m_streamListener);
+		pw_stream_destroy(m_stream);
+		m_stream = nullptr;
+		spa_hook_remove(&m_coreListener);
+		pw_core_disconnect(m_core);
+		m_core = nullptr;
+		pw_context_destroy(m_context);
+		m_context = nullptr;
+		pw_main_loop_destroy(m_loop);
+		m_loop = nullptr;
+		return false;
+	}
+
+	m_running = true;
+
+	// Run the PipeWire main loop in a dedicated thread so it doesn't block Qt
+	connect(&m_loopThread, &QThread::started, this, [this]() {
+		pw_main_loop_run(m_loop);
+	}, Qt::DirectConnection);
+	m_loopThread.start();
+
+	vDebug() << "PipeWire stream opened for node" << nodeId;
+	return true;
+}
+
+void PipeWireFramebuffer::close()
+{
+	m_running = false;
+
+	if (m_loop)
+	{
+		pw_main_loop_quit(m_loop);
+	}
+
+	if (m_loopThread.isRunning())
+	{
+		m_loopThread.quit();
+		m_loopThread.wait(3000);
+	}
+
+	if (m_stream)
+	{
+		spa_hook_remove(&m_streamListener);
+		pw_stream_disconnect(m_stream);
+		pw_stream_destroy(m_stream);
+		m_stream = nullptr;
+	}
+
+	if (m_core)
+	{
+		spa_hook_remove(&m_coreListener);
+		pw_core_disconnect(m_core);
+		m_core = nullptr;
+	}
+
+	if (m_context)
+	{
+		pw_context_destroy(m_context);
+		m_context = nullptr;
+	}
+
+	if (m_loop)
+	{
+		pw_main_loop_destroy(m_loop);
+		m_loop = nullptr;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PipeWire C callbacks (called from PipeWire loop thread)
+// ---------------------------------------------------------------------------
+
+void PipeWireFramebuffer::onCoreError(void* data, uint32_t /*id*/, int /*seq*/,
+									   int res, const char* message)
+{
+	auto* self = static_cast<PipeWireFramebuffer*>(data);
+	vCritical() << "PipeWire core error" << res << (message ? message : "");
+	self->m_running = false;
+	if (self->m_loop)
+	{
+		pw_main_loop_quit(self->m_loop);
+	}
+	Q_EMIT self->streamEnded();
+}
+
+void PipeWireFramebuffer::onStreamStateChanged(void* data,
+												pw_stream_state /*old*/,
+												pw_stream_state state,
+												const char* error)
+{
+	auto* self = static_cast<PipeWireFramebuffer*>(data);
+	vDebug() << "PipeWire stream state:" << pw_stream_state_as_string(state);
+
+	if (state == PW_STREAM_STATE_ERROR || state == PW_STREAM_STATE_UNCONNECTED)
+	{
+		if (error)
+		{
+			vCritical() << "PipeWire stream error:" << error;
+		}
+		self->m_running = false;
+		if (self->m_loop)
+		{
+			pw_main_loop_quit(self->m_loop);
+		}
+		Q_EMIT self->streamEnded();
+	}
+}
+
+void PipeWireFramebuffer::onStreamParamChanged(void* data, uint32_t id,
+												const spa_pod* param)
+{
+	auto* self = static_cast<PipeWireFramebuffer*>(data);
+
+	if (id != SPA_PARAM_Format || param == nullptr)
+	{
+		return;
+	}
+
+	spa_video_info_raw videoInfo{};
+	if (spa_format_video_raw_parse(param, &videoInfo) < 0)
+	{
+		return;
+	}
+
+	const int width  = static_cast<int>(videoInfo.size.width);
+	const int height = static_cast<int>(videoInfo.size.height);
+
+	if (width <= 0 || height <= 0)
+	{
+		return;
+	}
+
+	vDebug() << "PipeWire stream format:" << width << "x" << height
+			 << "format=" << videoInfo.format;
+
+	self->m_frameSize = QSize(width, height);
+	self->m_videoFormat = videoInfo.format;
+
+	// Accept the negotiated format by calling pw_stream_update_params with buffer
+	// params and a request for SPA_META_VideoDamage so the compositor can tell us
+	// which regions actually changed on each frame.
+	static constexpr int ParamBufSize = 1024;
+	uint8_t paramBuffer[ParamBufSize];
+	spa_pod_builder builder;
+	spa_pod_builder_init(&builder, paramBuffer, sizeof(paramBuffer));
+
+	// Allow up to MaxDamageRects damage rectangles per frame.
+	static constexpr int MaxDamageRects = 16;
+
+	const spa_pod* params[2];
+	params[0] = static_cast<const spa_pod*>(spa_pod_builder_add_object(
+		&builder,
+		SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
+		SPA_PARAM_BUFFERS_buffers,  SPA_POD_CHOICE_RANGE_Int(2, 1, 32),
+		SPA_PARAM_BUFFERS_blocks,   SPA_POD_Int(1),
+		SPA_PARAM_BUFFERS_size,     SPA_POD_Int(width * height * 4),
+		SPA_PARAM_BUFFERS_stride,   SPA_POD_Int(width * 4),
+		SPA_PARAM_BUFFERS_dataType, SPA_POD_CHOICE_FLAGS_Int(1 << SPA_DATA_MemPtr)
+	));
+	params[1] = static_cast<const spa_pod*>(spa_pod_builder_add_object(
+		&builder,
+		SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta,
+		SPA_PARAM_META_type, SPA_POD_Id(SPA_META_VideoDamage),
+		SPA_PARAM_META_size, SPA_POD_Int(static_cast<int>(sizeof(spa_meta_region)) * MaxDamageRects)
+	));
+
+	pw_stream_update_params(self->m_stream, params, 2);
+}
+
+void PipeWireFramebuffer::onStreamProcess(void* data)
+{
+	static_cast<PipeWireFramebuffer*>(data)->processFrame();
+}
+
+// ---------------------------------------------------------------------------
+// Frame processing (runs in PipeWire loop thread)
+// ---------------------------------------------------------------------------
+
+void PipeWireFramebuffer::processFrame()
+{
+	if (!m_stream || !m_rfbScreen)
+	{
+		return;
+	}
+
+	pw_buffer* pwBuf = pw_stream_dequeue_buffer(m_stream);
+	if (!pwBuf)
+	{
+		return;
+	}
+
+	spa_buffer* buf = pwBuf->buffer;
+	if (!buf || buf->n_datas == 0 || !buf->datas[0].data)
+	{
+		pw_stream_queue_buffer(m_stream, pwBuf);
+		return;
+	}
+
+	const int width  = m_frameSize.width();
+	const int height = m_frameSize.height();
+
+	if (width <= 0 || height <= 0)
+	{
+		pw_stream_queue_buffer(m_stream, pwBuf);
+		return;
+	}
+
+	// Resize rfbScreen framebuffer if the stream dimensions differ
+	const bool sizeChanged = (m_rfbScreen->width != width || m_rfbScreen->height != height);
+	if (sizeChanged)
+	{
+		const int newSize = width * height * 4;
+		char* newBuf = new char[newSize];
+		std::memset(newBuf, 0, static_cast<size_t>(newSize));
+		char* oldBuf = m_rfbScreen->frameBuffer;
+		rfbNewFramebuffer(m_rfbScreen, newBuf, width, height, 8, 3, 4);
+		delete[] oldBuf;
+	}
+
+	spa_data& d = buf->datas[0];
+	const int srcStride = d.chunk->stride > 0 ? d.chunk->stride : width * 4;
+	const int dstStride = width * 4;
+	const char* src = static_cast<const char*>(d.data) + d.chunk->offset;
+	char* dst = m_rfbScreen->frameBuffer;
+
+	if (m_videoFormat == SPA_VIDEO_FORMAT_BGRx)
+	{
+		for (int y = 0; y < height; ++y)
+		{
+			const auto* srcLine = reinterpret_cast<const uint8_t*>(src + y * srcStride);
+			auto* dstLine = reinterpret_cast<uint8_t*>(dst + y * dstStride);
+
+			for (int x = 0; x < width; ++x)
+			{
+				const int i = x * 4;
+				dstLine[i + 0] = srcLine[i + 2];
+				dstLine[i + 1] = srcLine[i + 1];
+				dstLine[i + 2] = srcLine[i + 0];
+				dstLine[i + 3] = srcLine[i + 3];
+			}
+		}
+	}
+	else
+	{
+		for (int y = 0; y < height; ++y)
+		{
+			std::memcpy(dst + y * dstStride, src + y * srcStride,
+						static_cast<size_t>(dstStride));
+		}
+	}
+
+	// Notify VNC clients about the changed regions.
+	// Try to use SPA_META_VideoDamage for precise dirty-rectangle tracking; fall
+	// back to marking the full frame when the compositor does not provide damage
+	// metadata or when the framebuffer was just resized.
+	const auto* damage = static_cast<const spa_meta_region*>(
+		spa_buffer_find_meta_data(buf, SPA_META_VideoDamage, sizeof(spa_meta_region)));
+
+	if (damage && spa_meta_region_is_valid(damage) && !sizeChanged)
+	{
+		for (const spa_meta_region* r = damage; spa_meta_region_is_valid(r); ++r)
+		{
+			// Clamp to framebuffer bounds
+			const int x1 = qBound(0, static_cast<int>(r->region.position.x), width);
+			const int y1 = qBound(0, static_cast<int>(r->region.position.y), height);
+			const int x2 = qBound(0, x1 + static_cast<int>(r->region.size.width), width);
+			const int y2 = qBound(0, y1 + static_cast<int>(r->region.size.height), height);
+			if (x2 > x1 && y2 > y1)
+			{
+				rfbMarkRectAsModified(m_rfbScreen, x1, y1, x2, y2);
+			}
+		}
+	}
+	else
+	{
+		rfbMarkRectAsModified(m_rfbScreen, 0, 0, width, height);
+	}
+
+	pw_stream_queue_buffer(m_stream, pwBuf);
+}

--- a/plugins/vncserver/pipewire/PipeWireFramebuffer.h
+++ b/plugins/vncserver/pipewire/PipeWireFramebuffer.h
@@ -1,0 +1,97 @@
+/*
+ * PipeWireFramebuffer.h - PipeWire stream consumer that fills an rfbScreen framebuffer
+ *
+ * Copyright (c) 2024-2026 Tobias Junghans <tobydox@veyon.io>
+ *
+ * This file is part of Veyon - https://veyon.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QSize>
+#include <QThread>
+
+extern "C" {
+#include <pipewire/pipewire.h>
+#include <spa/param/video/format-utils.h>
+#include <rfb/rfb.h>
+}
+
+/**
+ * @brief Connects to a PipeWire node and copies frames into an rfbScreen framebuffer.
+ *
+ * The PipeWire main loop runs in a dedicated QThread so it does not block Qt's
+ * event loop.  Format parameters are captured via the param_changed callback
+ * before frame processing begins.
+ *
+ * Typical use:
+ *   1. Call open() with a valid PipeWire remote FD and node ID.
+ *   2. Connect streamEnded() to handle reconnection.
+ *   3. Call close() to stop and release all resources.
+ */
+class PipeWireFramebuffer : public QObject
+{
+	Q_OBJECT
+public:
+	explicit PipeWireFramebuffer(QObject* parent = nullptr);
+	~PipeWireFramebuffer() override;
+
+	/**
+	 * @brief Open a PipeWire connection and start streaming into the rfbScreen.
+	 * @param fd      PipeWire remote FD (takes ownership)
+	 * @param nodeId  PipeWire node ID from portal Start response
+	 * @param screen  rfbScreen to write frames into (must outlive close())
+	 * @return true on success
+	 */
+	bool open(int fd, quint32 nodeId, rfbScreenInfoPtr screen);
+
+	/** @brief Stop the PipeWire loop and free all resources. */
+	void close();
+
+	bool isRunning() const { return m_running; }
+
+Q_SIGNALS:
+	void streamEnded();
+
+private:
+	// PipeWire C callbacks (called from PipeWire loop thread)
+	static void onCoreError(void* data, uint32_t id, int seq, int res, const char* message);
+	static void onStreamStateChanged(void* data, pw_stream_state old,
+	                                 pw_stream_state state, const char* error);
+	static void onStreamParamChanged(void* data, uint32_t id, const spa_pod* param);
+	static void onStreamProcess(void* data);
+
+	void processFrame();
+
+	pw_main_loop*    m_loop{nullptr};
+	pw_context*      m_context{nullptr};
+	pw_core*         m_core{nullptr};
+	pw_stream*       m_stream{nullptr};
+
+	spa_hook m_coreListener{};
+	spa_hook m_streamListener{};
+
+	rfbScreenInfoPtr m_rfbScreen{nullptr};
+	QSize            m_frameSize;
+	uint32_t         m_videoFormat{SPA_VIDEO_FORMAT_UNKNOWN};
+	bool             m_running{false};
+
+	QThread m_loopThread;
+};

--- a/plugins/vncserver/pipewire/PipeWireVncServer.cpp
+++ b/plugins/vncserver/pipewire/PipeWireVncServer.cpp
@@ -1,0 +1,290 @@
+/*
+ * PipeWireVncServer.cpp - Wayland VNC server backend using PipeWire + XDG Desktop Portal
+ *
+ * Copyright (c) 2024-2026 Tobias Junghans <tobydox@veyon.io>
+ *
+ * This file is part of Veyon - https://veyon.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+#include "PipeWireVncServer.h"
+#include "PipeWireFramebuffer.h"
+#include "PortalSession.h"
+
+#include "VeyonCore.h"
+#include "PlatformCoreFunctions.h"
+
+#include <QCoreApplication>
+#include <QThread>
+#include <QTimer>
+
+#include <cstring>
+
+// Initial framebuffer dimensions (used before the first PipeWire frame arrives)
+static constexpr int DefaultWidth  = 1920;
+static constexpr int DefaultHeight = 1080;
+// Qt event loop tick interval in milliseconds
+static constexpr int EventLoopTickMs = 25;
+
+
+PipeWireVncServer::PipeWireVncServer(QObject* parent)
+	: QObject(parent)
+{
+}
+
+PipeWireVncServer::~PipeWireVncServer()
+{
+	cleanupVncServer();
+}
+
+void PipeWireVncServer::prepareServer()
+{
+	VeyonCore::platform().coreFunctions().prepareSessionBusAccess();
+}
+
+bool PipeWireVncServer::runServer(int serverPort, const Password& password)
+{
+	if (VeyonCore::isDebugging())
+	{
+		rfbLog = rfbLogDebug;
+		rfbErr = rfbLogDebug;
+	}
+	else
+	{
+		rfbLog = rfbLogNone;
+		rfbErr = rfbLogNone;
+	}
+
+	if (!initVncServer(serverPort, password))
+	{
+		return false;
+	}
+
+	m_serverRunning = true;
+
+	// Portal session manages the XDG Desktop Portal RemoteDesktop DBus interaction.
+	// Created with nullptr parent to avoid the cross-thread QObject parent warning:
+	// runServer() is called from the VncServer thread while PipeWireVncServer itself
+	// lives on a different thread. Ownership is transferred to cleanupVncServer().
+	m_portalSession = new PortalSession(nullptr);
+	connect(m_portalSession, &PortalSession::started, this, &PipeWireVncServer::onPortalStarted,
+			Qt::QueuedConnection);
+	connect(m_portalSession, &PortalSession::failed,  this, &PipeWireVncServer::onPortalFailed,
+			Qt::QueuedConnection);
+
+	// PipeWireFramebuffer consumes the PipeWire stream and feeds the rfbScreen.
+	// Created with nullptr parent for the same cross-thread reason as m_portalSession.
+	m_framebuffer = new PipeWireFramebuffer(nullptr);
+	connect(m_framebuffer, &PipeWireFramebuffer::streamEnded,
+			this, &PipeWireVncServer::onStreamEnded, Qt::QueuedConnection);
+
+	// Start the portal flow asynchronously
+	m_portalSession->start();
+
+	// Drive the Qt event loop (portal DBus responses) and rfb clients
+	while (m_serverRunning)
+	{
+		QCoreApplication::processEvents(QEventLoop::AllEvents, EventLoopTickMs);
+
+		if (m_rfbScreen)
+		{
+			rfbProcessEvents(m_rfbScreen, 0);
+		}
+
+		if (m_shouldRestart)
+		{
+			m_shouldRestart = false;
+			vInfo() << "Restarting XDG Portal session";
+			m_portalSession->start();
+		}
+
+		QThread::msleep(10);
+	}
+
+	cleanupVncServer();
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Portal / stream callbacks
+// ---------------------------------------------------------------------------
+
+void PipeWireVncServer::onPortalStarted()
+{
+	vInfo() << "XDG Portal RemoteDesktop session started; opening PipeWire stream";
+
+	const int  fd     = m_portalSession->pipewireFd();
+	const auto nodeId = m_portalSession->pipeWireNodeId();
+
+	if (!m_framebuffer->open(fd, nodeId, m_rfbScreen))
+	{
+		vCritical() << "Failed to open PipeWire framebuffer – will retry";
+		QTimer::singleShot(5000, this, [this]() { m_shouldRestart = true; });
+	}
+}
+
+void PipeWireVncServer::onPortalFailed()
+{
+	vWarning() << "XDG Portal session failed – will retry in 5 s";
+	QTimer::singleShot(5000, this, [this]() { m_shouldRestart = true; });
+}
+
+void PipeWireVncServer::onStreamEnded()
+{
+	vInfo() << "PipeWire stream ended – closing session and reconnecting in 2 s";
+
+	if (m_framebuffer)
+	{
+		m_framebuffer->close();
+	}
+	if (m_portalSession)
+	{
+		m_portalSession->close();
+	}
+
+	QTimer::singleShot(2000, this, [this]() { m_shouldRestart = true; });
+}
+
+// ---------------------------------------------------------------------------
+// LibVNCServer setup / teardown
+// ---------------------------------------------------------------------------
+
+bool PipeWireVncServer::initVncServer(int serverPort, const Password& password)
+{
+	const int fbSize = DefaultWidth * DefaultHeight * 4;
+	m_framebufferData = new char[fbSize];
+	std::memset(m_framebufferData, 0, static_cast<size_t>(fbSize));
+
+	m_rfbScreen = rfbGetScreen(nullptr, nullptr, DefaultWidth, DefaultHeight, 8, 3, 4);
+	if (!m_rfbScreen)
+	{
+		vCritical() << "rfbGetScreen failed";
+		delete[] m_framebufferData;
+		m_framebufferData = nullptr;
+		return false;
+	}
+
+	m_vncPassword = qstrdup(password.toByteArray().constData());
+	m_vncPasswords[0] = m_vncPassword;
+	m_vncPasswords[1] = nullptr;
+
+	m_rfbScreen->desktopName     = "VeyonVNC";
+	m_rfbScreen->frameBuffer     = m_framebufferData;
+	m_rfbScreen->port            = serverPort;
+	m_rfbScreen->ipv6port        = serverPort;
+	m_rfbScreen->authPasswdData  = m_vncPasswords;
+	m_rfbScreen->passwordCheck   = rfbCheckPasswordByList;
+
+	m_rfbScreen->serverFormat.redShift     = 16;
+	m_rfbScreen->serverFormat.greenShift   = 8;
+	m_rfbScreen->serverFormat.blueShift    = 0;
+	m_rfbScreen->serverFormat.redMax       = 255;
+	m_rfbScreen->serverFormat.greenMax     = 255;
+	m_rfbScreen->serverFormat.blueMax      = 255;
+	m_rfbScreen->serverFormat.trueColour   = true;
+	m_rfbScreen->serverFormat.bitsPerPixel = 32;
+
+	m_rfbScreen->alwaysShared        = true;
+	m_rfbScreen->handleEventsEagerly = true;
+	m_rfbScreen->deferUpdateTime     = 5;
+	m_rfbScreen->cursor              = nullptr;
+
+	// Store a back-pointer so the static C callbacks can access this instance.
+	m_rfbScreen->screenData = this;
+	m_rfbScreen->kbdAddEvent = &PipeWireVncServer::onKbdAddEvent;
+	m_rfbScreen->ptrAddEvent = &PipeWireVncServer::onPtrAddEvent;
+
+	rfbInitServer(m_rfbScreen);
+	rfbMarkRectAsModified(m_rfbScreen, 0, 0, DefaultWidth, DefaultHeight);
+
+	return true;
+}
+
+void PipeWireVncServer::cleanupVncServer()
+{
+	m_serverRunning = false;
+
+	if (m_framebuffer)
+	{
+		m_framebuffer->close();
+		delete m_framebuffer;
+		m_framebuffer = nullptr;
+	}
+
+	if (m_portalSession)
+	{
+		m_portalSession->close();
+		delete m_portalSession;
+		m_portalSession = nullptr;
+	}
+
+	if (m_rfbScreen)
+	{
+		rfbShutdownServer(m_rfbScreen, true);
+		rfbScreenCleanup(m_rfbScreen);
+		m_rfbScreen = nullptr;
+	}
+
+	delete[] m_framebufferData;
+	m_framebufferData = nullptr;
+
+	delete[] m_vncPassword;
+	m_vncPassword = nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// LibVNCServer logging
+// ---------------------------------------------------------------------------
+
+void PipeWireVncServer::rfbLogDebug(const char* format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	static constexpr int MaxLen = 256;
+	char msg[MaxLen];
+	vsnprintf(msg, sizeof(msg), format, args);
+	msg[MaxLen - 1] = 0;
+	va_end(args);
+	vDebug() << msg;
+}
+
+void PipeWireVncServer::rfbLogNone(const char* /*format*/, ...)
+{
+}
+
+// ---------------------------------------------------------------------------
+// LibVNCServer input event callbacks
+// ---------------------------------------------------------------------------
+
+void PipeWireVncServer::onKbdAddEvent(rfbBool down, rfbKeySym keySym, rfbClientRec* cl)
+{
+	auto* self = static_cast<PipeWireVncServer*>(cl->screen->screenData);
+	if (self->m_portalSession)
+	{
+		self->m_portalSession->notifyKeyboardKeysym(static_cast<quint32>(keySym), down != 0);
+	}
+}
+
+void PipeWireVncServer::onPtrAddEvent(int buttonMask, int x, int y, rfbClientRec* cl)
+{
+	auto* self = static_cast<PipeWireVncServer*>(cl->screen->screenData);
+	if (self->m_portalSession)
+	{
+		self->m_portalSession->notifyPointer(buttonMask, x, y);
+	}
+}

--- a/plugins/vncserver/pipewire/PipeWireVncServer.h
+++ b/plugins/vncserver/pipewire/PipeWireVncServer.h
@@ -1,0 +1,145 @@
+/*
+ * PipeWireVncServer.h - Wayland VNC server backend using PipeWire + XDG Desktop Portal
+ *
+ * Copyright (c) 2024-2026 Tobias Junghans <tobydox@veyon.io>
+ *
+ * This file is part of Veyon - https://veyon.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+#pragma once
+
+#include "PluginInterface.h"
+#include "VncServerPluginInterface.h"
+
+class PortalSession;
+class PipeWireFramebuffer;
+
+extern "C" {
+#include <rfb/rfb.h>
+}
+
+/**
+ * @brief Wayland VNC server plugin using XDG Desktop Portal RemoteDesktop + PipeWire.
+ *
+ * Acquires a screen capture via the org.freedesktop.portal.RemoteDesktop D-Bus API
+ * and feeds the resulting PipeWire stream into a LibVNCServer rfbScreen so that VNC
+ * clients can connect and receive screen updates.
+ *
+ * The plugin uses the stable application identifier "io.veyon.veyon-server".
+ * KDE Plasma 6.3+ administrators can pre-authorize unattended access with:
+ *
+ *   flatpak permission-set kde-authorized screencast io.veyon.veyon-server yes
+ *
+ * See plugins/vncserver/pipewire/README.md for full pre-authorization details.
+ */
+class PipeWireVncServer : public QObject, VncServerPluginInterface, PluginInterface
+{
+	Q_OBJECT
+	Q_PLUGIN_METADATA(IID "io.veyon.Veyon.Plugins.PipeWireVncServer")
+	Q_INTERFACES(PluginInterface VncServerPluginInterface)
+
+public:
+	explicit PipeWireVncServer(QObject* parent = nullptr);
+	~PipeWireVncServer() override;
+
+	Plugin::Uid uid() const override
+	{
+		return Plugin::Uid{ QStringLiteral("3b8e5c1a-9f72-4d3e-b6a0-2c7f1e8d4b95") };
+	}
+
+	QVersionNumber version() const override
+	{
+		return QVersionNumber(1, 0);
+	}
+
+	QString name() const override
+	{
+		return QStringLiteral("PipeWireVncServer");
+	}
+
+	QString description() const override
+	{
+		return tr("Wayland VNC server (PipeWire/XDG Portal)");
+	}
+
+	QString vendor() const override
+	{
+		return QStringLiteral("Veyon Community");
+	}
+
+	QString copyright() const override
+	{
+		return QStringLiteral("Tobias Junghans");
+	}
+
+	Plugin::Flags flags() const override
+	{
+		return Plugin::NoFlags;
+	}
+
+	QStringList supportedSessionTypes() const override
+	{
+		return { QStringLiteral("wayland") };
+	}
+
+	QWidget* configurationWidget() override
+	{
+		return nullptr;
+	}
+
+	void prepareServer() override;
+
+	bool runServer(int serverPort, const Password& password) override;
+
+	int configuredServerPort() override
+	{
+		return -1;
+	}
+
+	Password configuredPassword() override
+	{
+		return {};
+	}
+
+private Q_SLOTS:
+	void onPortalStarted();
+	void onPortalFailed();
+	void onStreamEnded();
+
+private:
+	bool initVncServer(int serverPort, const Password& password);
+	void cleanupVncServer();
+
+	static void rfbLogDebug(const char* format, ...);
+	static void rfbLogNone(const char* format, ...);
+
+	// LibVNCServer input event callbacks (C linkage function pointers)
+	static void onKbdAddEvent(rfbBool down, rfbKeySym keySym, rfbClientRec* cl);
+	static void onPtrAddEvent(int buttonMask, int x, int y, rfbClientRec* cl);
+
+	PortalSession*       m_portalSession{nullptr};
+	PipeWireFramebuffer* m_framebuffer{nullptr};
+	rfbScreenInfoPtr     m_rfbScreen{nullptr};
+	char*                m_framebufferData{nullptr};
+	char*                m_vncPassword{nullptr};
+	char*                m_vncPasswords[2]{nullptr, nullptr};
+
+	bool m_serverRunning{false};
+	bool m_shouldRestart{false};
+};

--- a/plugins/vncserver/pipewire/PipeWireVncServer.h
+++ b/plugins/vncserver/pipewire/PipeWireVncServer.h
@@ -90,7 +90,7 @@ public:
 
 	Plugin::Flags flags() const override
 	{
-		return Plugin::NoFlags;
+		return Plugin::ProvidesDefaultImplementation;
 	}
 
 	QStringList supportedSessionTypes() const override

--- a/plugins/vncserver/pipewire/PortalSession.cpp
+++ b/plugins/vncserver/pipewire/PortalSession.cpp
@@ -1,0 +1,489 @@
+/*
+ * PortalSession.cpp - XDG Desktop Portal RemoteDesktop session management
+ *
+ * Copyright (c) 2024-2026 Tobias Junghans <tobydox@veyon.io>
+ *
+ * This file is part of Veyon - https://veyon.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+#include <linux/input.h>
+
+#include <QDBusArgument>
+#include <QDBusObjectPath>
+#include <QDBusPendingCallWatcher>
+#include <QDBusPendingReply>
+#include <QDBusUnixFileDescriptor>
+#include <QRandomGenerator>
+
+#include "PortalSession.h"
+#include "VeyonCore.h"
+
+// XDG Desktop Portal service and interface names
+static const auto PortalService = QStringLiteral("org.freedesktop.portal.Desktop");
+static const auto PortalObjectPath = QStringLiteral("/org/freedesktop/portal/desktop");
+static const auto ConnectionName = QStringLiteral("PipeWirePortalSession");
+
+PortalSession::PortalSession(QObject* parent)
+	: QObject(parent)
+	, m_sessionBus(QDBusConnection::connectToBus(QDBusConnection::SessionBus, ConnectionName))
+{
+	const auto appId = QGuiApplication::desktopFileName();
+
+	QProcess::execute(QStringLiteral("flatpak"),
+					  {QStringLiteral("permission-set"), QStringLiteral("kde-authorized"),
+					   QStringLiteral("screencast"), appId, QStringLiteral("yes")});
+	QProcess::execute(QStringLiteral("flatpak"),
+					  {QStringLiteral("permission-set"), QStringLiteral("kde-authorized"),
+					   QStringLiteral("remote-desktop"), appId, QStringLiteral("yes")});
+
+	if (!m_sessionBus.registerService(appId))
+	{
+		vWarning() << "Could not register D-Bus service name" << appId
+				   << ":" << m_sessionBus.lastError().message();
+	}
+
+	m_remoteDesktop = new OrgFreedesktopPortalRemoteDesktopInterface(PortalService, PortalObjectPath, m_sessionBus, this);
+	m_screenCast = new OrgFreedesktopPortalScreenCastInterface(PortalService, PortalObjectPath, m_sessionBus, this);
+}
+
+
+
+PortalSession::~PortalSession()
+{
+	close();
+	m_sessionBus.unregisterService(QGuiApplication::desktopFileName());
+	m_sessionBus.disconnectFromBus(ConnectionName);
+}
+
+
+
+void PortalSession::start()
+{
+	if (m_state != State::Idle && m_state != State::Failed)
+	{
+		return;
+	}
+	m_pipewireFd = -1;
+	m_pipeWireNodeId = 0;
+	m_sessionHandle.clear();
+	createSession();
+}
+
+
+
+void PortalSession::close()
+{
+	disconnectResponseSignal();
+
+	if (!m_sessionHandle.isEmpty())
+	{
+		OrgFreedesktopPortalSessionInterface sessionIface(
+			PortalService, m_sessionHandle, m_sessionBus);
+		sessionIface.Close();
+		m_sessionHandle.clear();
+	}
+
+	setState(State::Idle);
+}
+
+
+
+void PortalSession::createSession()
+{
+	setState(State::CreatingSession);
+
+	const QString token = makeRequestToken();
+
+	QVariantMap options;
+	options[QStringLiteral("handle_token")] = token;
+	options[QStringLiteral("session_handle_token")] = makeRequestToken();
+
+	// Subscribe to the Response signal BEFORE making the async call to avoid a
+	// race condition where the portal emits Response before we can connect.
+	connectResponseSignal(makeRequestPath(token));
+
+	auto call = m_remoteDesktop->CreateSession(options);
+	auto* watcher = new QDBusPendingCallWatcher(call, this);
+	connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
+		w->deleteLater();
+		QDBusPendingReply<QDBusObjectPath> reply = *w;
+		if (reply.isError())
+		{
+			vCritical() << "CreateSession call failed:" << reply.error().message();
+			disconnectResponseSignal();
+			setState(State::Failed);
+			Q_EMIT failed();
+		}
+	});
+}
+
+
+
+void PortalSession::selectDevices()
+{
+	setState(State::SelectingDevices);
+
+	const QString token = makeRequestToken();
+
+	QVariantMap options;
+	options[QStringLiteral("handle_token")] = token;
+	// Request keyboard + pointer devices (1=keyboard, 2=pointer, 3=both)
+	options[QStringLiteral("types")] = QVariant::fromValue<uint>(3u);
+	// persist_mode 2 = persist until explicitly revoked
+	options[QStringLiteral("persist_mode")] = QVariant::fromValue<uint>(2u);
+	if (!m_restoreToken.isEmpty())
+	{
+		options[QStringLiteral("restore_token")] = m_restoreToken;
+	}
+
+	connectResponseSignal(makeRequestPath(token));
+
+	auto call = m_remoteDesktop->SelectDevices(QDBusObjectPath(m_sessionHandle), options);
+	connect(new QDBusPendingCallWatcher(call, this), &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
+		w->deleteLater();
+		QDBusPendingReply<QDBusObjectPath> reply = *w;
+		if (reply.isError())
+		{
+			vCritical() << "SelectDevices call failed:" << reply.error().message();
+			disconnectResponseSignal();
+			setState(State::Failed);
+			Q_EMIT failed();
+		}
+	});
+}
+
+
+
+void PortalSession::selectSources()
+{
+	setState(State::SelectingSources);
+
+	const QString token = makeRequestToken();
+
+	QVariantMap options;
+	options[QStringLiteral("handle_token")] = token;
+	options[QStringLiteral("types")]        = QVariant::fromValue<uint>(1u); // 1=monitor
+	options[QStringLiteral("multiple")]     = false;
+	// ScreenCast interface only supports persist_mode=0; persist_mode=2 is
+	// only valid on the RemoteDesktop interface (used in selectDevices()).
+	options[QStringLiteral("persist_mode")] = QVariant::fromValue<uint>(0u);
+
+	connectResponseSignal(makeRequestPath(token));
+
+	auto call = m_screenCast->SelectSources(QDBusObjectPath(m_sessionHandle), options);
+	auto* watcher = new QDBusPendingCallWatcher(call, this);
+	connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
+		w->deleteLater();
+		QDBusPendingReply<QDBusObjectPath> reply = *w;
+		if (reply.isError())
+		{
+			vCritical() << "SelectSources call failed:" << reply.error().message();
+			disconnectResponseSignal();
+			setState(State::Failed);
+			Q_EMIT failed();
+		}
+	});
+}
+
+
+
+void PortalSession::startSession()
+{
+	setState(State::Starting);
+
+	const QString token = makeRequestToken();
+
+	QVariantMap options;
+	options[QStringLiteral("handle_token")] = token;
+
+	connectResponseSignal(makeRequestPath(token));
+
+	auto call = m_remoteDesktop->Start(
+		QDBusObjectPath(m_sessionHandle),
+		QStringLiteral(""), // parent_window handle (empty for daemon/unattended use)
+		options
+	);
+	auto* watcher = new QDBusPendingCallWatcher(call, this);
+	connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
+		w->deleteLater();
+		QDBusPendingReply<QDBusObjectPath> reply = *w;
+		if (reply.isError())
+		{
+			vCritical() << "Start call failed:" << reply.error().message();
+			disconnectResponseSignal();
+			setState(State::Failed);
+			Q_EMIT failed();
+		}
+	});
+}
+
+
+
+void PortalSession::openPipeWireRemote()
+{
+	auto pending = m_screenCast->OpenPipeWireRemote(
+		QDBusObjectPath(m_sessionHandle), QVariantMap{});
+	pending.waitForFinished();
+
+	if (pending.isError())
+	{
+		vCritical() << "OpenPipeWireRemote failed:" << pending.error().message();
+		setState(State::Failed);
+		Q_EMIT failed();
+		return;
+	}
+
+	// dup() the FD so we own it independently of the QDBus reply lifetime
+	m_pipewireFd = ::dup(pending.value().fileDescriptor());
+	if (m_pipewireFd < 0)
+	{
+		vCritical() << "dup() of PipeWire FD failed";
+		setState(State::Failed);
+		Q_EMIT failed();
+		return;
+	}
+
+	setState(State::Running);
+	Q_EMIT started();
+}
+
+
+
+void PortalSession::connectResponseSignal(const QString& requestPath)
+{
+	disconnectResponseSignal();
+
+	m_connectedRequestPath = requestPath;
+	m_requestInterface = new OrgFreedesktopPortalRequestInterface(
+		PortalService, requestPath, m_sessionBus, this);
+
+	connect(m_requestInterface, &OrgFreedesktopPortalRequestInterface::Response,
+			this, &PortalSession::onPortalResponse);
+}
+
+
+
+void PortalSession::disconnectResponseSignal()
+{
+	delete m_requestInterface;
+	m_requestInterface = nullptr;
+	m_connectedRequestPath.clear();
+}
+
+
+
+void PortalSession::onPortalResponse(uint response, const QVariantMap& results)
+{
+	disconnectResponseSignal();
+
+	if (response != 0)
+	{
+		vWarning() << "Portal request in state" << static_cast<int>(m_state)
+				   << "denied/cancelled (response=" << response << ")";
+		setState(State::Failed);
+		Q_EMIT failed();
+		return;
+	}
+
+	// Save restore token whenever the portal provides one
+	if (results.contains(QStringLiteral("restore_token")))
+	{
+		m_restoreToken = results.value(QStringLiteral("restore_token")).toString();
+		vDebug() << "Got portal restore_token:" << m_restoreToken;
+	}
+
+	switch (m_state)
+	{
+	case State::CreatingSession:
+	{
+		// session_handle can arrive as QDBusObjectPath or as a plain string
+		QDBusObjectPath sessionPath = results.value(QStringLiteral("session_handle")).value<QDBusObjectPath>();
+		m_sessionHandle = sessionPath.path().isEmpty()
+						  ? results.value(QStringLiteral("session_handle")).toString()
+						  : sessionPath.path();
+
+		if (m_sessionHandle.isEmpty())
+		{
+			vCritical() << "CreateSession response missing session_handle";
+			setState(State::Failed);
+			Q_EMIT failed();
+			return;
+		}
+		vDebug() << "Portal session created:" << m_sessionHandle;
+		selectDevices();
+		break;
+	}
+
+	case State::SelectingDevices:
+		selectSources();
+		break;
+
+	case State::SelectingSources:
+		startSession();
+		break;
+
+	case State::Starting:
+	{
+		// The streams result is an array of (node_id, properties) structs.
+		// Extract the first node ID.
+		const QDBusArgument streams = results.value(QStringLiteral("streams")).value<QDBusArgument>();
+		if (!streams.currentSignature().isEmpty())
+		{
+			streams.beginArray();
+			if (!streams.atEnd())
+			{
+				streams.beginStructure();
+				streams >> m_pipeWireNodeId;
+				streams.endStructure();
+			}
+			streams.endArray();
+		}
+
+		vDebug() << "Portal session started, PipeWire node ID:" << m_pipeWireNodeId;
+		openPipeWireRemote();
+		break;
+	}
+
+	default:
+		vWarning() << "Unexpected portal response in state" << static_cast<int>(m_state);
+		break;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+void PortalSession::setState(State s)
+{
+	m_state = s;
+}
+
+QString PortalSession::makeRequestToken() const
+{
+	return QStringLiteral("veyon_%1").arg(QRandomGenerator::global()->generate());
+}
+
+QString PortalSession::senderToken() const
+{
+	return m_sessionBus.baseService().remove(QLatin1Char(':')).replace(QLatin1Char('.'), QLatin1Char('_'));
+}
+
+QString PortalSession::makeRequestPath(const QString& token) const
+{
+	return QStringLiteral("/org/freedesktop/portal/desktop/request/%1/%2").arg(senderToken(), token);
+}
+
+// ---------------------------------------------------------------------------
+// Input event forwarding
+// ---------------------------------------------------------------------------
+
+void PortalSession::notifyKeyboardKeysym(quint32 keySym, bool down)
+{
+	if (m_state != State::Running)
+	{
+		return;
+	}
+
+	// Portal state: 0 = released, 1 = pressed
+	m_remoteDesktop->NotifyKeyboardKeysym(
+		QDBusObjectPath(m_sessionHandle),
+		QVariantMap{},
+		static_cast<int>(keySym),
+		down ? 1u : 0u);
+}
+
+void PortalSession::notifyPointer(int buttonMask, int x, int y)
+{
+	if (m_state != State::Running || m_pipeWireNodeId == 0)
+	{
+		return;
+	}
+
+	const auto sessionPath = QDBusObjectPath(m_sessionHandle);
+	const double dx = static_cast<double>(x);
+	const double dy = static_cast<double>(y);
+
+	// Send motion event when the position changed
+	if (dx != m_lastPointerX || dy != m_lastPointerY)
+	{
+		m_remoteDesktop->NotifyPointerMotionAbsolute(
+			sessionPath, QVariantMap{}, m_pipeWireNodeId, dx, dy);
+		m_lastPointerX = dx;
+		m_lastPointerY = dy;
+	}
+
+	// Send button/scroll events for every bit that changed
+	if (buttonMask != m_lastButtonMask)
+	{
+		// Linux evdev button codes matching VNC button mask bits 0–8
+		// Bits 3-6 are scroll directions (no evdev button code — use axis)
+		static const int evdevButtons[] = {
+			BTN_LEFT,   // bit 0
+			BTN_MIDDLE, // bit 1
+			BTN_RIGHT,  // bit 2
+			0,          // bit 3 – scroll up   (axis event)
+			0,          // bit 4 – scroll down (axis event)
+			0,          // bit 5 – scroll left (axis event)
+			0,          // bit 6 – scroll right (axis event)
+			BTN_SIDE,   // bit 7
+			BTN_EXTRA,  // bit 8
+		};
+		static constexpr int numButtons = static_cast<int>(sizeof(evdevButtons) / sizeof(evdevButtons[0]));
+
+		for (int i = 0; i < numButtons; ++i)
+		{
+			const int prev    = (m_lastButtonMask >> i) & 1;
+			const int current = (buttonMask >> i) & 1;
+			if (prev == current)
+			{
+				continue;
+			}
+
+			if (evdevButtons[i] != 0)
+			{
+				// Regular button press/release (0=released, 1=pressed)
+				m_remoteDesktop->NotifyPointerButton(
+					sessionPath, QVariantMap{}, evdevButtons[i], static_cast<uint>(current));
+			}
+			else if (current != 0)
+			{
+				// Scroll axis: only fire on press (the release has no discrete step)
+				int axis  = 0; // 0 = vertical
+				int steps = 0;
+				switch (i)
+				{
+				case 3: axis = 0; steps = -1; break; // scroll up
+				case 4: axis = 0; steps =  1; break; // scroll down
+				case 5: axis = 1; steps = -1; break; // scroll left
+				case 6: axis = 1; steps =  1; break; // scroll right
+				default: break;
+				}
+				if (steps != 0)
+				{
+					m_remoteDesktop->NotifyPointerAxisDiscrete(
+						sessionPath, QVariantMap{}, static_cast<uint>(axis), steps);
+				}
+			}
+		}
+
+		m_lastButtonMask = buttonMask;
+	}
+}
+

--- a/plugins/vncserver/pipewire/PortalSession.cpp
+++ b/plugins/vncserver/pipewire/PortalSession.cpp
@@ -23,12 +23,15 @@
  */
 
 #include <linux/input.h>
+#include <unistd.h>
 
 #include <QDBusArgument>
 #include <QDBusObjectPath>
 #include <QDBusPendingCallWatcher>
 #include <QDBusPendingReply>
 #include <QDBusUnixFileDescriptor>
+#include <QGuiApplication>
+#include <QProcess>
 #include <QRandomGenerator>
 
 #include "PortalSession.h"
@@ -37,14 +40,21 @@
 // XDG Desktop Portal service and interface names
 static const auto PortalService = QStringLiteral("org.freedesktop.portal.Desktop");
 static const auto PortalObjectPath = QStringLiteral("/org/freedesktop/portal/desktop");
-static const auto ConnectionName = QStringLiteral("PipeWirePortalSession");
-
 PortalSession::PortalSession(QObject* parent)
 	: QObject(parent)
-	, m_sessionBus(QDBusConnection::connectToBus(QDBusConnection::SessionBus, ConnectionName))
+	, m_sessionBus(QDBusConnection::sessionBus())
 {
 	const auto appId = QGuiApplication::desktopFileName();
 
+	// Use the default session bus connection so the portal can properly
+	// identify this application by its well-known bus name and match
+	// pre-authorized permissions. Creating a separate connection would
+	// cause the portal to see a numeric :1.xx ID instead of the app ID,
+	// which breaks pre-authorization via flatpak permission-set.
+
+	// Apply KDE pre-authorization so the consent dialog can be suppressed
+	// in unattended/kiosk scenarios. These calls are best-effort and may
+	// fail silently if flatpak is not installed.
 	QProcess::execute(QStringLiteral("flatpak"),
 					  {QStringLiteral("permission-set"), QStringLiteral("kde-authorized"),
 					   QStringLiteral("screencast"), appId, QStringLiteral("yes")});
@@ -52,10 +62,13 @@ PortalSession::PortalSession(QObject* parent)
 					  {QStringLiteral("permission-set"), QStringLiteral("kde-authorized"),
 					   QStringLiteral("remote-desktop"), appId, QStringLiteral("yes")});
 
+	// Register the well-known name so the portal can resolve our app ID.
+	// This is not strictly required when using the default session bus,
+	// but helps consistency for logging and debugging.
 	if (!m_sessionBus.registerService(appId))
 	{
-		vWarning() << "Could not register D-Bus service name" << appId
-				   << ":" << m_sessionBus.lastError().message();
+		vDebug() << "Could not register D-Bus service name" << appId
+				 << ":" << m_sessionBus.lastError().message();
 	}
 
 	m_remoteDesktop = new OrgFreedesktopPortalRemoteDesktopInterface(PortalService, PortalObjectPath, m_sessionBus, this);
@@ -68,7 +81,6 @@ PortalSession::~PortalSession()
 {
 	close();
 	m_sessionBus.unregisterService(QGuiApplication::desktopFileName());
-	m_sessionBus.disconnectFromBus(ConnectionName);
 }
 
 

--- a/plugins/vncserver/pipewire/PortalSession.h
+++ b/plugins/vncserver/pipewire/PortalSession.h
@@ -1,0 +1,155 @@
+/*
+ * PortalSession.h - XDG Desktop Portal RemoteDesktop session management
+ *
+ * Copyright (c) 2024-2026 Tobias Junghans <tobydox@veyon.io>
+ *
+ * This file is part of Veyon - https://veyon.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+#pragma once
+
+#include <QDBusConnection>
+#include <QDBusObjectPath>
+#include <QObject>
+#include <QString>
+#include <QVariantMap>
+
+#include "OrgFreedesktopPortalRemoteDesktop.h"
+#include "OrgFreedesktopPortalRequest.h"
+#include "OrgFreedesktopPortalScreenCast.h"
+#include "OrgFreedesktopPortalSession.h"
+
+/**
+ * @brief Manages an XDG Desktop Portal RemoteDesktop session.
+ *
+ * Follows the portal flow:
+ *   CreateSession → SelectDevices → SelectSources → Start → OpenPipeWireRemote
+ *
+ * All portal responses arrive asynchronously via the /org/freedesktop/portal/desktop/response
+ * signal and are dispatched to the appropriate handler.
+ *
+ * The app_id used for permission-store lookups is "io.veyon.Veyon.Server".
+ * KDE Plasma admins can pre-authorize unattended access via:
+ *   flatpak permission-set kde-authorized screencast io.veyon.Veyon.Server yes
+ * or directly through the DBus PermissionStore interface.
+ */
+class PortalSession : public QObject
+{
+	Q_OBJECT
+
+public:
+	enum class State {
+		Idle,
+		CreatingSession,
+		SelectingDevices,
+		SelectingSources,
+		Starting,
+		Running,
+		Failed
+	};
+	Q_ENUM(State)
+
+	explicit PortalSession(QObject* parent = nullptr);
+	~PortalSession() override;
+
+	/**
+	 * @brief Start the portal session flow.
+	 * Emits started() on success or failed() on error.
+	 */
+	void start();
+
+	/**
+	 * @brief Close and clean up the portal session.
+	 */
+	void close();
+
+	State state() const { return m_state; }
+
+	/**
+	 * @brief PipeWire remote file descriptor (valid after started() signal).
+	 * The caller takes ownership (must close when done).
+	 */
+	int pipewireFd() const { return m_pipewireFd; }
+
+	/**
+	 * @brief PipeWire node ID for the screen stream (valid after started() signal).
+	 */
+	quint32 pipeWireNodeId() const { return m_pipeWireNodeId; }
+
+	/**
+	 * @brief Forward a keyboard keysym event from a VNC client to the portal session.
+	 *
+	 * The @p keySym value is the X11 keysym received from the VNC client (rfbKeySym).
+	 * No-op when the session is not in the Running state.
+	 */
+	void notifyKeyboardKeysym(quint32 keySym, bool down);
+
+	/**
+	 * @brief Forward a pointer (mouse) event from a VNC client to the portal session.
+	 *
+	 * Sends NotifyPointerMotionAbsolute when the position changes and
+	 * NotifyPointerButton / NotifyPointerAxisDiscrete when button state changes.
+	 * No-op when the session is not in the Running state.
+	 *
+	 * @p buttonMask is the LibVNCServer button bitmask (bit 0 = left, 1 = middle,
+	 * 2 = right, 3 = scroll-up, 4 = scroll-down, 5 = scroll-left, 6 = scroll-right,
+	 * 7 = side, 8 = extra).
+	 */
+	void notifyPointer(int buttonMask, int x, int y);
+
+Q_SIGNALS:
+	void started();
+	void failed();
+
+private Q_SLOTS:
+	void onPortalResponse(uint response, const QVariantMap& results);
+
+private:
+	void createSession();
+	void selectDevices();
+	void selectSources();
+	void startSession();
+	void openPipeWireRemote();
+
+	void connectResponseSignal(const QString& requestPath);
+	void disconnectResponseSignal();
+
+	void setState(State s);
+
+	QString makeRequestToken() const;
+	QString senderToken() const;
+	QString makeRequestPath(const QString& token) const;
+
+	QDBusConnection m_sessionBus;
+	OrgFreedesktopPortalRemoteDesktopInterface* m_remoteDesktop{nullptr};
+	OrgFreedesktopPortalScreenCastInterface* m_screenCast{nullptr};
+	OrgFreedesktopPortalRequestInterface* m_requestInterface{nullptr};
+
+	QString m_sessionHandle;
+	QString m_restoreToken;
+	State m_state{State::Idle};
+	int m_pipewireFd{-1};
+	quint32 m_pipeWireNodeId{0};
+	QString m_connectedRequestPath;
+
+	int m_lastButtonMask{0};
+	double m_lastPointerX{0.0};
+	double m_lastPointerY{0.0};
+
+};

--- a/plugins/vncserver/pipewire/PortalSession.h
+++ b/plugins/vncserver/pipewire/PortalSession.h
@@ -44,9 +44,9 @@
  * All portal responses arrive asynchronously via the /org/freedesktop/portal/desktop/response
  * signal and are dispatched to the appropriate handler.
  *
- * The app_id used for permission-store lookups is "io.veyon.Veyon.Server".
+ * The app_id used for permission-store lookups is "io.veyon.veyon-server".
  * KDE Plasma admins can pre-authorize unattended access via:
- *   flatpak permission-set kde-authorized screencast io.veyon.Veyon.Server yes
+ *   flatpak permission-set kde-authorized screencast io.veyon.veyon-server yes
  * or directly through the DBus PermissionStore interface.
  */
 class PortalSession : public QObject

--- a/plugins/vncserver/pipewire/README.md
+++ b/plugins/vncserver/pipewire/README.md
@@ -1,0 +1,183 @@
+# Veyon PipeWire VNC Server Plugin
+
+Wayland VNC server backend for the Veyon Server using
+**PipeWire** and the **XDG Desktop Portal RemoteDesktop** API.
+
+## Overview
+
+Under Wayland, X11-based screen capture (e.g., x11vnc) is not available.
+This plugin uses the standard `org.freedesktop.portal.RemoteDesktop` D-Bus
+interface to request screen content and input device access via
+[xdg-desktop-portal](https://github.com/flatpak/xdg-desktop-portal),
+then receives the video stream through a PipeWire remote and feeds it into
+LibVNCServer so that VNC clients can connect.
+
+### Portal flow
+
+```
+CreateSession  →  SelectDevices  →  SelectSources  →  Start  →  OpenPipeWireRemote
+```
+
+All steps are asynchronous via the portal `Response` signal.
+If the stream ends (e.g., compositor restart) the session is automatically
+restarted after a short delay.
+
+## Dependencies
+
+| Dependency | Debian package |
+|---|---|
+| PipeWire ≥ 0.3 | `libpipewire-0.3-dev` |
+| xdg-desktop-portal | `xdg-desktop-portal` |
+| xdg-desktop-portal-kde (KDE) | `xdg-desktop-portal-kde` |
+| LibVNCServer ≥ 0.9.8 | `libvncserver-dev` |
+| Qt5 DBus | `qtbase5-dev` (included) |
+
+## Application identifier
+
+The plugin registers itself under the stable application identifier:
+
+```
+io.veyon.Veyon.Server
+```
+
+This identifier is used by the XDG Desktop Portal permission store.
+A consistent, non-Flatpak identifier is needed so that permissions granted by
+an administrator survive service restarts.
+
+The identifier is registered in three complementary ways:
+
+1. **D-Bus well-known name** — `PortalSession` calls
+   `QDBusConnection::sessionBus().registerService("io.veyon.Veyon.Server")`
+   at start-up so the portal sees the correct app_id for every method call.
+
+2. **XDG `.desktop` file** — `io.veyon.Veyon.Server.desktop` is installed to
+   `/usr/share/applications/`.  The portal reads `Name=Veyon Server` from it
+   to display "Veyon Server" (instead of the terminal emulator or process name)
+   in the KDE permission dialog.
+
+3. **D-Bus session service file** — `io.veyon.Veyon.Server.service` is
+   installed to `/usr/share/dbus-1/services/`.  It maps the well-known bus name
+   to the `veyon-server` executable so dbus-daemon and xdg-desktop-portal can
+   follow the full `bus_name → desktop_file → display_name` chain.
+
+## Pre-authorization for KDE Plasma 6.3+
+
+By default the portal will display a consent dialog the first time the Veyon
+Server requests screen access.  In a classroom or kiosk scenario this dialog
+must be suppressed so that the server daemon can start without user
+interaction.
+
+KDE Plasma 6.3+ supports permanent pre-authorization via the portal permission
+store table `kde-authorized`.
+
+### Method 1: `flatpak permission-set` (recommended)
+
+```bash
+flatpak permission-set kde-authorized screencast io.veyon.Veyon.Server yes
+```
+
+This command must be run **as the target user** (the user whose desktop is to
+be captured), not as root.
+
+### Method 2: D-Bus PermissionStore
+
+If the `flatpak` CLI is not installed, you can use `dbus-send` directly:
+
+```bash
+dbus-send \
+  --session \
+  --print-reply \
+  --dest=org.freedesktop.impl.portal.PermissionStore \
+  /org/freedesktop/impl/portal/PermissionStore \
+  org.freedesktop.impl.portal.PermissionStore.SetPermission \
+  string:kde-authorized \
+  boolean:false \
+  string:screencast \
+  string:io.veyon.Veyon.Server \
+  array:string:yes
+```
+
+### Helper script
+
+A convenience script is installed to `/usr/share/veyon/veyon-preauth-kde.sh`.
+It tries Method 1 first and falls back to Method 2:
+
+```bash
+sudo -u <desktop-user> \
+  DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$(id -u <desktop-user>)/bus" \
+  /usr/share/veyon/veyon-preauth-kde.sh
+```
+
+### Debian post-install integration
+
+In a Debian package, add a `postinst` snippet that runs the helper for each
+auto-login user:
+
+```sh
+# debian/veyon-server.postinst
+VEYON_USER="student"  # adjust to the auto-login user
+
+if [ -S "/run/user/$(id -u ${VEYON_USER})/bus" ]; then
+    sudo -u "${VEYON_USER}" \
+        DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$(id -u ${VEYON_USER})/bus" \
+        /usr/share/veyon/veyon-preauth-kde.sh || true
+fi
+```
+
+### systemd service considerations
+
+The Veyon Server is typically started as a system-level service (`root` or a
+dedicated system user).  Under Wayland the portal, however, runs inside the
+**user session** of the logged-in user whose screen is being shared.
+
+The recommended setup is:
+
+1. Run `veyon-server` as the **desktop user** (not root), or use `systemd --user`
+   with `WantedBy=graphical-session.target`.
+2. Ensure `DBUS_SESSION_BUS_ADDRESS` and `WAYLAND_DISPLAY` are forwarded to
+   the service environment (see `ImportCredential=` / `PassEnvironment=`).
+3. Run the pre-authorization script once during provisioning (post-install or
+   cloud-init).
+
+Example `veyon-server.service` override (`/etc/systemd/user/veyon-server.service`):
+
+```ini
+[Unit]
+Description=Veyon Server (Wayland/PipeWire)
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/veyon-server
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=graphical-session.target
+```
+
+Enable it as the desktop user:
+
+```bash
+systemctl --user enable --now veyon-server
+```
+
+## Limitations and known issues
+
+* **GNOME**: GNOME's portal backend does not currently support the
+  `kde-authorized` pre-authorization table.  An interactive consent dialog
+  will appear on first use.  Persistent `restore_token` support (portal v2+)
+  reduces subsequent prompts to zero after the first manual approval.
+
+* **Input forwarding**: The plugin requests both keyboard and pointer device
+  types via `SelectDevices`.  Key presses and releases are forwarded using
+  `NotifyKeyboardKeysym`.  Pointer motion is forwarded as absolute coordinates
+  via `NotifyPointerMotionAbsolute`, button presses/releases via
+  `NotifyPointerButton`, and scroll wheel events via
+  `NotifyPointerAxisDiscrete`.  All input events are ignored until the portal
+  session is in the `Running` state.
+
+* **Multi-monitor**: `SelectSources` currently requests a single monitor.
+  Multi-monitor support can be added by iterating stream node IDs returned by
+  the portal `Start` response.

--- a/plugins/vncserver/pipewire/README.md
+++ b/plugins/vncserver/pipewire/README.md
@@ -37,7 +37,7 @@ restarted after a short delay.
 The plugin registers itself under the stable application identifier:
 
 ```
-io.veyon.Veyon.Server
+io.veyon.veyon-server
 ```
 
 This identifier is used by the XDG Desktop Portal permission store.
@@ -47,15 +47,15 @@ an administrator survive service restarts.
 The identifier is registered in three complementary ways:
 
 1. **D-Bus well-known name** — `PortalSession` calls
-   `QDBusConnection::sessionBus().registerService("io.veyon.Veyon.Server")`
+   `QDBusConnection::sessionBus().registerService("io.veyon.veyon-server")`
    at start-up so the portal sees the correct app_id for every method call.
 
-2. **XDG `.desktop` file** — `io.veyon.Veyon.Server.desktop` is installed to
+2. **XDG `.desktop` file** — `io.veyon.veyon-server.desktop` is installed to
    `/usr/share/applications/`.  The portal reads `Name=Veyon Server` from it
    to display "Veyon Server" (instead of the terminal emulator or process name)
    in the KDE permission dialog.
 
-3. **D-Bus session service file** — `io.veyon.Veyon.Server.service` is
+3. **D-Bus session service file** — `io.veyon.veyon-server.service` is
    installed to `/usr/share/dbus-1/services/`.  It maps the well-known bus name
    to the `veyon-server` executable so dbus-daemon and xdg-desktop-portal can
    follow the full `bus_name → desktop_file → display_name` chain.
@@ -73,7 +73,7 @@ store table `kde-authorized`.
 ### Method 1: `flatpak permission-set` (recommended)
 
 ```bash
-flatpak permission-set kde-authorized screencast io.veyon.Veyon.Server yes
+flatpak permission-set kde-authorized screencast io.veyon.veyon-server yes
 ```
 
 This command must be run **as the target user** (the user whose desktop is to
@@ -93,7 +93,7 @@ dbus-send \
   string:kde-authorized \
   boolean:false \
   string:screencast \
-  string:io.veyon.Veyon.Server \
+  string:io.veyon.veyon-server \
   array:string:yes
 ```
 

--- a/plugins/vncserver/pipewire/dbus/org.freedesktop.portal.RemoteDesktop.xml
+++ b/plugins/vncserver/pipewire/dbus/org.freedesktop.portal.RemoteDesktop.xml
@@ -1,0 +1,66 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <!--
+    org.freedesktop.portal.RemoteDesktop:
+    XDG Desktop Portal interface for remote desktop (keyboard/pointer) access.
+    Source: https://github.com/flatpak/xdg-desktop-portal/blob/main/data/org.freedesktop.portal.RemoteDesktop.xml
+  -->
+  <interface name="org.freedesktop.portal.RemoteDesktop">
+
+    <method name="CreateSession">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o"     name="handle"  direction="out"/>
+    </method>
+
+    <method name="SelectDevices">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+      <arg type="o"     name="session_handle" direction="in"/>
+      <arg type="a{sv}" name="options"        direction="in"/>
+      <arg type="o"     name="handle"         direction="out"/>
+    </method>
+
+    <method name="Start">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
+      <arg type="o"     name="session_handle" direction="in"/>
+      <arg type="s"     name="parent_window"  direction="in"/>
+      <arg type="a{sv}" name="options"        direction="in"/>
+      <arg type="o"     name="handle"         direction="out"/>
+    </method>
+
+    <method name="NotifyKeyboardKeysym">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+      <arg type="o"     name="session_handle" direction="in"/>
+      <arg type="a{sv}" name="options"        direction="in"/>
+      <arg type="i"     name="keysym"         direction="in"/>
+      <arg type="u"     name="state"          direction="in"/>
+    </method>
+
+    <method name="NotifyPointerMotionAbsolute">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+      <arg type="o"     name="session_handle" direction="in"/>
+      <arg type="a{sv}" name="options"        direction="in"/>
+      <arg type="u"     name="stream"         direction="in"/>
+      <arg type="d"     name="x"              direction="in"/>
+      <arg type="d"     name="y"              direction="in"/>
+    </method>
+
+    <method name="NotifyPointerButton">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+      <arg type="o"     name="session_handle" direction="in"/>
+      <arg type="a{sv}" name="options"        direction="in"/>
+      <arg type="i"     name="button"         direction="in"/>
+      <arg type="u"     name="state"          direction="in"/>
+    </method>
+
+    <method name="NotifyPointerAxisDiscrete">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+      <arg type="o"     name="session_handle" direction="in"/>
+      <arg type="a{sv}" name="options"        direction="in"/>
+      <arg type="u"     name="axis"           direction="in"/>
+      <arg type="i"     name="steps"          direction="in"/>
+    </method>
+
+  </interface>
+</node>

--- a/plugins/vncserver/pipewire/dbus/org.freedesktop.portal.Request.xml
+++ b/plugins/vncserver/pipewire/dbus/org.freedesktop.portal.Request.xml
@@ -1,0 +1,22 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <!--
+    org.freedesktop.portal.Request:
+    XDG Desktop Portal request object – each portal method call creates a Request
+    object whose path is returned as "handle".  The Response signal fires once
+    the user interacts with the portal dialog (or the request completes).
+    Source: https://github.com/flatpak/xdg-desktop-portal/blob/main/data/org.freedesktop.portal.Request.xml
+  -->
+  <interface name="org.freedesktop.portal.Request">
+
+    <method name="Close"/>
+
+    <signal name="Response">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap"/>
+      <arg type="u"     name="response"/>
+      <arg type="a{sv}" name="results"/>
+    </signal>
+
+  </interface>
+</node>

--- a/plugins/vncserver/pipewire/dbus/org.freedesktop.portal.ScreenCast.xml
+++ b/plugins/vncserver/pipewire/dbus/org.freedesktop.portal.ScreenCast.xml
@@ -1,0 +1,26 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <!--
+    org.freedesktop.portal.ScreenCast:
+    XDG Desktop Portal interface for screen capture streams.
+    Source: https://github.com/flatpak/xdg-desktop-portal/blob/main/data/org.freedesktop.portal.ScreenCast.xml
+  -->
+  <interface name="org.freedesktop.portal.ScreenCast">
+
+    <method name="SelectSources">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+      <arg type="o"     name="session_handle" direction="in"/>
+      <arg type="a{sv}" name="options"        direction="in"/>
+      <arg type="o"     name="handle"         direction="out"/>
+    </method>
+
+    <method name="OpenPipeWireRemote">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+      <arg type="o"     name="session_handle" direction="in"/>
+      <arg type="a{sv}" name="options"        direction="in"/>
+      <arg type="h"     name="fd"             direction="out"/>
+    </method>
+
+  </interface>
+</node>

--- a/plugins/vncserver/pipewire/dbus/org.freedesktop.portal.Session.xml
+++ b/plugins/vncserver/pipewire/dbus/org.freedesktop.portal.Session.xml
@@ -1,0 +1,15 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <!--
+    org.freedesktop.portal.Session:
+    XDG Desktop Portal session object – represents an open portal session.
+    Close() terminates the session and releases associated resources.
+    Source: https://github.com/flatpak/xdg-desktop-portal/blob/main/data/org.freedesktop.portal.Session.xml
+  -->
+  <interface name="org.freedesktop.portal.Session">
+
+    <method name="Close"/>
+
+  </interface>
+</node>

--- a/plugins/vncserver/pipewire/veyon-preauth-kde.sh
+++ b/plugins/vncserver/pipewire/veyon-preauth-kde.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# veyon-preauth-kde.sh – Pre-authorize Veyon Server for unattended KDE Plasma screen access
+#
+# Copyright (c) 2024-2026 Tobias Junghans <tobydox@veyon.io>
+#
+# This file is part of Veyon - https://veyon.io
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Usage:
+#   Run this script as the *target user* (the user whose desktop will be captured),
+#   or from a post-install hook that has access to that user's session bus.
+#
+#   sudo -u <target-user> DBUS_SESSION_BUS_ADDRESS="$(cat /run/user/<uid>/bus)" \
+#       /usr/share/veyon/veyon-preauth-kde.sh
+#
+# Requirements:
+#   - KDE Plasma 6.3 or later
+#   - xdg-desktop-portal-kde installed and running
+#   - Either 'flatpak' CLI or direct DBus access to the PermissionStore
+#
+# What this script does:
+#   Grants "io.veyon.Veyon.Server" permanent permission for RemoteDesktop portal
+#   access under KDE.  After running this script the Veyon Server daemon will be
+#   able to capture the screen and receive input without any interactive portal
+#   consent dialog.
+#
+# Stable app_id used: io.veyon.Veyon.Server
+# Permission table  : kde-authorized
+# Permission type   : screencast
+
+APP_ID="io.veyon.Veyon.Server"
+TABLE="kde-authorized"
+# KDE Plasma's PermissionStore uses "screencast" (not "remote-desktop") as the
+# permission ID for the kde-authorized screen-capture pre-authorization table.
+PERM_TYPE="screencast"
+
+set -e
+
+echo "Veyon KDE pre-authorization script"
+echo "  App ID : ${APP_ID}"
+echo "  Table  : ${TABLE}"
+echo "  Type   : ${PERM_TYPE}"
+echo ""
+
+# Method 1: use the flatpak CLI if available (simplest)
+if command -v flatpak >/dev/null 2>&1; then
+    echo "Using 'flatpak permission-set' ..."
+    flatpak permission-set "${TABLE}" "${PERM_TYPE}" "${APP_ID}" yes
+    echo "Done."
+    exit 0
+fi
+
+# Method 2: call the DBus PermissionStore directly
+echo "flatpak CLI not found; using DBus PermissionStore directly ..."
+
+if ! command -v dbus-send >/dev/null 2>&1; then
+    echo "ERROR: neither 'flatpak' nor 'dbus-send' found. Cannot set permission." >&2
+    exit 1
+fi
+
+dbus-send \
+    --session \
+    --print-reply \
+    --dest=org.freedesktop.impl.portal.PermissionStore \
+    /org/freedesktop/impl/portal/PermissionStore \
+    org.freedesktop.impl.portal.PermissionStore.SetPermission \
+    "string:${TABLE}" \
+    "boolean:false" \
+    "string:${PERM_TYPE}" \
+    "string:${APP_ID}" \
+    "array:string:yes"
+
+echo "Done."

--- a/plugins/vncserver/pipewire/veyon-preauth-kde.sh
+++ b/plugins/vncserver/pipewire/veyon-preauth-kde.sh
@@ -20,16 +20,16 @@
 #   - Either 'flatpak' CLI or direct DBus access to the PermissionStore
 #
 # What this script does:
-#   Grants "io.veyon.Veyon.Server" permanent permission for RemoteDesktop portal
+#   Grants "io.veyon.veyon-server" permanent permission for RemoteDesktop portal
 #   access under KDE.  After running this script the Veyon Server daemon will be
 #   able to capture the screen and receive input without any interactive portal
 #   consent dialog.
 #
-# Stable app_id used: io.veyon.Veyon.Server
+# Stable app_id used: io.veyon.veyon-server
 # Permission table  : kde-authorized
 # Permission type   : screencast
 
-APP_ID="io.veyon.Veyon.Server"
+APP_ID="io.veyon.veyon-server"
 TABLE="kde-authorized"
 # KDE Plasma's PermissionStore uses "screencast" (not "remote-desktop") as the
 # permission ID for the kde-authorized screen-capture pre-authorization table.

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -21,3 +21,26 @@ build_veyon_application(veyon-server
 	src/VncProxyServer.h
 	src/VncServer.cpp
 	src/VncServer.h)
+
+configure_file(
+	"${CMAKE_CURRENT_SOURCE_DIR}/data/io.veyon.veyon-server.desktop.in"
+	"${CMAKE_CURRENT_BINARY_DIR}/data/io.veyon.veyon-server.desktop"
+	@ONLY
+)
+configure_file(
+	"${CMAKE_CURRENT_SOURCE_DIR}/data/io.veyon.veyon-server.service.in"
+	"${CMAKE_CURRENT_BINARY_DIR}/data/io.veyon.veyon-server.service"
+	@ONLY
+)
+
+install(
+	FILES "${CMAKE_CURRENT_BINARY_DIR}/data/io.veyon.veyon-server.desktop"
+	DESTINATION "${CMAKE_INSTALL_DATADIR}/applications"
+	COMPONENT pipewire-vnc-server
+)
+
+install(
+	FILES "${CMAKE_CURRENT_BINARY_DIR}/data/io.veyon.veyon-server.service"
+	DESTINATION "${CMAKE_INSTALL_DATADIR}/dbus-1/services"
+	COMPONENT pipewire-vnc-server
+)

--- a/server/data/io.veyon.veyon-server.desktop.in
+++ b/server/data/io.veyon.veyon-server.desktop.in
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.5
+Type=Application
+NoDisplay=true
+Exec=@CMAKE_INSTALL_PREFIX@/bin/veyon-server
+Name=Veyon Server
+Comment=Veyon remote desktop server
+Icon=veyon
+Categories=Qt;Education;Network;RemoteAccess;

--- a/server/data/io.veyon.veyon-server.service.in
+++ b/server/data/io.veyon.veyon-server.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=io.veyon.veyon-server
+Exec=@CMAKE_INSTALL_PREFIX@/bin/veyon-server

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -32,6 +32,7 @@ int main( int argc, char **argv )
 	VeyonCore::setupApplicationParameters();
 
 	QGuiApplication app( argc, argv );
+	QGuiApplication::setDesktopFileName(QStringLiteral("io.veyon.veyon-server"));
 
 	VeyonCore core( &app, VeyonCore::Component::Server, QStringLiteral("Server") );
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
 if(WITH_FUZZERS)
 	add_subdirectory(libfuzzer)
 endif()
+
+add_subdirectory(unit)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,0 +1,47 @@
+if(WITH_TESTS AND VEYON_BUILD_LINUX)
+
+	find_package(X11 REQUIRED)
+
+	#
+	# LinuxKeyboardMappingTest: tests keysym → linux keycode mapping tables
+	# and UTF-8 → linux keycode conversion.
+	#
+	add_executable(LinuxKeyboardMappingTest
+		LinuxKeyboardMappingTest.cpp
+		${CMAKE_SOURCE_DIR}/plugins/platform/linux/LinuxKeyboardInput.cpp
+		${CMAKE_SOURCE_DIR}/3rdparty/libfakekey/src/libfakekey.c
+	)
+
+	target_include_directories(LinuxKeyboardMappingTest PRIVATE
+		${CMAKE_SOURCE_DIR}/plugins/platform/linux
+		${CMAKE_SOURCE_DIR}/3rdparty/libfakekey
+		${CMAKE_SOURCE_DIR}/core/src
+		${CMAKE_SOURCE_DIR}/core/src/Configuration
+	)
+
+	target_link_libraries(LinuxKeyboardMappingTest PRIVATE
+		Qt${QT_MAJOR_VERSION}::Test
+		Qt${QT_MAJOR_VERSION}::Core
+		veyon-core
+		${X11_LIBRARIES}
+		${X11_XTest_LIB}
+	)
+
+	add_test(NAME LinuxKeyboardMappingTest COMMAND LinuxKeyboardMappingTest)
+
+	#
+	# PipeWireVncServerTest: tests BGRx→RGB conversion, damage rect clamping,
+	# and portal session token/path generation.
+	#
+	add_executable(PipeWireVncServerTest
+		PipeWireVncServerTest.cpp
+	)
+
+	target_link_libraries(PipeWireVncServerTest PRIVATE
+		Qt${QT_MAJOR_VERSION}::Test
+		Qt${QT_MAJOR_VERSION}::Core
+	)
+
+	add_test(NAME PipeWireVncServerTest COMMAND PipeWireVncServerTest)
+
+endif()

--- a/tests/unit/LinuxKeyboardMappingTest.cpp
+++ b/tests/unit/LinuxKeyboardMappingTest.cpp
@@ -1,0 +1,355 @@
+/*
+ * LinuxKeyboardMappingTest.cpp - test keysym/UTF-8 to Linux keycode mapping
+ *
+ * Copyright (c) 2019-2026 Tobias Junghans <tobydox@veyon.io>
+ *
+ * This file is part of Veyon - https://veyon.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+#include <QObject>
+#include <QTest>
+
+// include linux input constants for KEY_MENU etc.
+#include <linux/input.h>
+
+
+#define private public
+#include "LinuxKeyboardInput.h"
+#undef private
+
+class LinuxKeyboardMappingTest : public QObject
+{
+	Q_OBJECT
+
+private Q_SLOTS:
+	void testKeysymToLinuxKeycode_data();
+	void testKeysymToLinuxKeycode();
+	void testUtf8ToLinuxKeycode_data();
+	void testUtf8ToLinuxKeycode();
+	void testUnmappedKeysymReturnsMinusOne();
+	void testUnmappedUtf8ReturnsMinusOne();
+};
+
+void LinuxKeyboardMappingTest::testKeysymToLinuxKeycode_data()
+{
+	QTest::addColumn<quint32>("keysym");
+	QTest::addColumn<int>("expectedKeycode");
+
+	// a-z
+	QTest::addRow("a") << quint32(0x0061) << 30;
+	QTest::addRow("b") << quint32(0x0062) << 48;
+	QTest::addRow("c") << quint32(0x0063) << 46;
+	QTest::addRow("d") << quint32(0x0064) << 32;
+	QTest::addRow("e") << quint32(0x0065) << 18;
+	QTest::addRow("f") << quint32(0x0066) << 33;
+	QTest::addRow("g") << quint32(0x0067) << 34;
+	QTest::addRow("h") << quint32(0x0068) << 35;
+	QTest::addRow("i") << quint32(0x0069) << 23;
+	QTest::addRow("j") << quint32(0x006a) << 36;
+	QTest::addRow("k") << quint32(0x006b) << 37;
+	QTest::addRow("l") << quint32(0x006c) << 38;
+	QTest::addRow("m") << quint32(0x006d) << 50;
+	QTest::addRow("n") << quint32(0x006e) << 49;
+	QTest::addRow("o") << quint32(0x006f) << 24;
+	QTest::addRow("p") << quint32(0x0070) << 25;
+	QTest::addRow("q") << quint32(0x0071) << 16;
+	QTest::addRow("r") << quint32(0x0072) << 19;
+	QTest::addRow("s") << quint32(0x0073) << 31;
+	QTest::addRow("t") << quint32(0x0074) << 20;
+	QTest::addRow("u") << quint32(0x0075) << 22;
+	QTest::addRow("v") << quint32(0x0076) << 47;
+	QTest::addRow("w") << quint32(0x0077) << 17;
+	QTest::addRow("x") << quint32(0x0078) << 45;
+	QTest::addRow("y") << quint32(0x0079) << 21;
+	QTest::addRow("z") << quint32(0x007a) << 44;
+
+	// A-Z
+	QTest::addRow("A") << quint32(0x0041) << 30;
+	QTest::addRow("B") << quint32(0x0042) << 48;
+	QTest::addRow("C") << quint32(0x0043) << 46;
+	QTest::addRow("D") << quint32(0x0044) << 32;
+	QTest::addRow("E") << quint32(0x0045) << 18;
+	QTest::addRow("F") << quint32(0x0046) << 33;
+	QTest::addRow("G") << quint32(0x0047) << 34;
+	QTest::addRow("H") << quint32(0x0048) << 35;
+	QTest::addRow("I") << quint32(0x0049) << 23;
+	QTest::addRow("J") << quint32(0x004a) << 36;
+	QTest::addRow("K") << quint32(0x004b) << 37;
+	QTest::addRow("L") << quint32(0x004c) << 38;
+	QTest::addRow("M") << quint32(0x004d) << 50;
+	QTest::addRow("N") << quint32(0x004e) << 49;
+	QTest::addRow("O") << quint32(0x004f) << 24;
+	QTest::addRow("P") << quint32(0x0050) << 25;
+	QTest::addRow("Q") << quint32(0x0051) << 16;
+	QTest::addRow("R") << quint32(0x0052) << 19;
+	QTest::addRow("S") << quint32(0x0053) << 31;
+	QTest::addRow("T") << quint32(0x0054) << 20;
+	QTest::addRow("U") << quint32(0x0055) << 22;
+	QTest::addRow("V") << quint32(0x0056) << 47;
+	QTest::addRow("W") << quint32(0x0057) << 17;
+	QTest::addRow("X") << quint32(0x0058) << 45;
+	QTest::addRow("Y") << quint32(0x0059) << 21;
+	QTest::addRow("Z") << quint32(0x005a) << 44;
+
+	// Digits 0-9
+	QTest::addRow("digit_0") << quint32(0x0030) << 11;
+	QTest::addRow("digit_1") << quint32(0x0031) << 2;
+	QTest::addRow("digit_2") << quint32(0x0032) << 3;
+	QTest::addRow("digit_3") << quint32(0x0033) << 4;
+	QTest::addRow("digit_4") << quint32(0x0034) << 5;
+	QTest::addRow("digit_5") << quint32(0x0035) << 6;
+	QTest::addRow("digit_6") << quint32(0x0036) << 7;
+	QTest::addRow("digit_7") << quint32(0x0037) << 8;
+	QTest::addRow("digit_8") << quint32(0x0038) << 9;
+	QTest::addRow("digit_9") << quint32(0x0039) << 10;
+
+	// Punctuation and symbols
+	QTest::addRow("Minus") << quint32(0x002d) << 12;
+	QTest::addRow("Equal") << quint32(0x003d) << 13;
+	QTest::addRow("BracketLeft") << quint32(0x005b) << 26;
+	QTest::addRow("BracketRight") << quint32(0x005d) << 27;
+	QTest::addRow("Semicolon") << quint32(0x003b) << 39;
+	QTest::addRow("Apostrophe") << quint32(0x0027) << 40;
+	QTest::addRow("Grave") << quint32(0x0060) << 41;
+	QTest::addRow("Backslash") << quint32(0x005c) << 43;
+	QTest::addRow("Comma") << quint32(0x002c) << 51;
+	QTest::addRow("Period") << quint32(0x002e) << 52;
+	QTest::addRow("Slash") << quint32(0x002f) << 53;
+
+	// Modifier keys
+	QTest::addRow("Shift_L") << quint32(0xffe1) << 42;
+	QTest::addRow("Shift_R") << quint32(0xffe2) << 54;
+	QTest::addRow("Control_L") << quint32(0xffe3) << 29;
+	QTest::addRow("Control_R") << quint32(0xffe4) << 97;
+	QTest::addRow("Alt_L") << quint32(0xffe9) << 56;
+	QTest::addRow("Alt_R") << quint32(0xffea) << 100;
+	QTest::addRow("Super_L") << quint32(0xffeb) << 125;
+	QTest::addRow("Super_R") << quint32(0xffec) << 126;
+	QTest::addRow("Menu") << quint32(0xff67) << KEY_MENU;
+
+	// Whitespace and editing keys
+	QTest::addRow("Space") << quint32(0x0020) << 57;
+	QTest::addRow("Return") << quint32(0xff0d) << 28;
+	QTest::addRow("Tab") << quint32(0xff09) << 15;
+	QTest::addRow("BackSpace") << quint32(0xff08) << 14;
+	QTest::addRow("Escape") << quint32(0xff1b) << 1;
+
+	// Navigation keys
+	QTest::addRow("Home") << quint32(0xff50) << 102;
+	QTest::addRow("Up") << quint32(0xff52) << 103;
+	QTest::addRow("Prior") << quint32(0xff55) << 104;
+	QTest::addRow("Left") << quint32(0xff51) << 105;
+	QTest::addRow("Right") << quint32(0xff53) << 106;
+	QTest::addRow("End") << quint32(0xff57) << 107;
+	QTest::addRow("Down") << quint32(0xff54) << 108;
+	QTest::addRow("Next") << quint32(0xff56) << 109;
+	QTest::addRow("Insert") << quint32(0xff63) << 110;
+	QTest::addRow("Delete") << quint32(0xffff) << 111;
+
+	// Function keys
+	QTest::addRow("F1") << quint32(0xffbe) << 59;
+	QTest::addRow("F2") << quint32(0xffbf) << 60;
+	QTest::addRow("F3") << quint32(0xffc0) << 61;
+	QTest::addRow("F4") << quint32(0xffc1) << 62;
+	QTest::addRow("F5") << quint32(0xffc2) << 63;
+	QTest::addRow("F6") << quint32(0xffc3) << 64;
+	QTest::addRow("F7") << quint32(0xffc4) << 65;
+	QTest::addRow("F8") << quint32(0xffc5) << 66;
+	QTest::addRow("F9") << quint32(0xffc6) << 67;
+	QTest::addRow("F10") << quint32(0xffc7) << 68;
+	QTest::addRow("F11") << quint32(0xffc8) << 87;
+	QTest::addRow("F12") << quint32(0xffc9) << 88;
+
+	// Lock keys
+	QTest::addRow("Caps_Lock") << quint32(0xffe5) << 58;
+	QTest::addRow("Num_Lock") << quint32(0xff7f) << 69;
+	QTest::addRow("Scroll_Lock") << quint32(0xff14) << 70;
+	QTest::addRow("Print") << quint32(0xff61) << 99;
+
+	// Keypad keys
+	QTest::addRow("KP_Multiply") << quint32(0xffaa) << 55;
+	QTest::addRow("KP_7") << quint32(0xffb7) << 71;
+	QTest::addRow("KP_8") << quint32(0xffb8) << 72;
+	QTest::addRow("KP_9") << quint32(0xffb9) << 73;
+	QTest::addRow("KP_Subtract") << quint32(0xffad) << 74;
+	QTest::addRow("KP_4") << quint32(0xffb4) << 75;
+	QTest::addRow("KP_5") << quint32(0xffb5) << 76;
+	QTest::addRow("KP_6") << quint32(0xffb6) << 77;
+	QTest::addRow("KP_Add") << quint32(0xffab) << 78;
+	QTest::addRow("KP_1") << quint32(0xffb1) << 79;
+	QTest::addRow("KP_2") << quint32(0xffb2) << 80;
+	QTest::addRow("KP_3") << quint32(0xffb3) << 81;
+	QTest::addRow("KP_0") << quint32(0xffb0) << 82;
+	QTest::addRow("KP_Decimal") << quint32(0xffae) << 83;
+	QTest::addRow("KP_Enter") << quint32(0xff8d) << 96;
+	QTest::addRow("KP_Divide") << quint32(0xffaf) << 98;
+}
+
+void LinuxKeyboardMappingTest::testKeysymToLinuxKeycode()
+{
+	QFETCH(quint32, keysym);
+	QFETCH(int, expectedKeycode);
+
+	QCOMPARE(LinuxKeyboardInput::keysymToLinuxKeycode(keysym), expectedKeycode);
+}
+
+void LinuxKeyboardMappingTest::testUtf8ToLinuxKeycode_data()
+{
+	QTest::addColumn<QByteArray>("utf8");
+	QTest::addColumn<int>("expectedKeycode");
+
+	// a-z
+	QTest::addRow("a") << QByteArrayLiteral("a") << 30;
+	QTest::addRow("b") << QByteArrayLiteral("b") << 48;
+	QTest::addRow("c") << QByteArrayLiteral("c") << 46;
+	QTest::addRow("d") << QByteArrayLiteral("d") << 32;
+	QTest::addRow("e") << QByteArrayLiteral("e") << 18;
+	QTest::addRow("f") << QByteArrayLiteral("f") << 33;
+	QTest::addRow("g") << QByteArrayLiteral("g") << 34;
+	QTest::addRow("h") << QByteArrayLiteral("h") << 35;
+	QTest::addRow("i") << QByteArrayLiteral("i") << 23;
+	QTest::addRow("j") << QByteArrayLiteral("j") << 36;
+	QTest::addRow("k") << QByteArrayLiteral("k") << 37;
+	QTest::addRow("l") << QByteArrayLiteral("l") << 38;
+	QTest::addRow("m") << QByteArrayLiteral("m") << 50;
+	QTest::addRow("n") << QByteArrayLiteral("n") << 49;
+	QTest::addRow("o") << QByteArrayLiteral("o") << 24;
+	QTest::addRow("p") << QByteArrayLiteral("p") << 25;
+	QTest::addRow("q") << QByteArrayLiteral("q") << 16;
+	QTest::addRow("r") << QByteArrayLiteral("r") << 19;
+	QTest::addRow("s") << QByteArrayLiteral("s") << 31;
+	QTest::addRow("t") << QByteArrayLiteral("t") << 20;
+	QTest::addRow("u") << QByteArrayLiteral("u") << 22;
+	QTest::addRow("v") << QByteArrayLiteral("v") << 47;
+	QTest::addRow("w") << QByteArrayLiteral("w") << 17;
+	QTest::addRow("x") << QByteArrayLiteral("x") << 45;
+	QTest::addRow("y") << QByteArrayLiteral("y") << 21;
+	QTest::addRow("z") << QByteArrayLiteral("z") << 44;
+
+	// A-Z
+	QTest::addRow("A") << QByteArrayLiteral("A") << 30;
+	QTest::addRow("B") << QByteArrayLiteral("B") << 48;
+	QTest::addRow("C") << QByteArrayLiteral("C") << 46;
+	QTest::addRow("D") << QByteArrayLiteral("D") << 32;
+	QTest::addRow("E") << QByteArrayLiteral("E") << 18;
+	QTest::addRow("F") << QByteArrayLiteral("F") << 33;
+	QTest::addRow("G") << QByteArrayLiteral("G") << 34;
+	QTest::addRow("H") << QByteArrayLiteral("H") << 35;
+	QTest::addRow("I") << QByteArrayLiteral("I") << 23;
+	QTest::addRow("J") << QByteArrayLiteral("J") << 36;
+	QTest::addRow("K") << QByteArrayLiteral("K") << 37;
+	QTest::addRow("L") << QByteArrayLiteral("L") << 38;
+	QTest::addRow("M") << QByteArrayLiteral("M") << 50;
+	QTest::addRow("N") << QByteArrayLiteral("N") << 49;
+	QTest::addRow("O") << QByteArrayLiteral("O") << 24;
+	QTest::addRow("P") << QByteArrayLiteral("P") << 25;
+	QTest::addRow("Q") << QByteArrayLiteral("Q") << 16;
+	QTest::addRow("R") << QByteArrayLiteral("R") << 19;
+	QTest::addRow("S") << QByteArrayLiteral("S") << 31;
+	QTest::addRow("T") << QByteArrayLiteral("T") << 20;
+	QTest::addRow("U") << QByteArrayLiteral("U") << 22;
+	QTest::addRow("V") << QByteArrayLiteral("V") << 47;
+	QTest::addRow("W") << QByteArrayLiteral("W") << 17;
+	QTest::addRow("X") << QByteArrayLiteral("X") << 45;
+	QTest::addRow("Y") << QByteArrayLiteral("Y") << 21;
+	QTest::addRow("Z") << QByteArrayLiteral("Z") << 44;
+
+	// Digits
+	QTest::addRow("digit_0") << QByteArrayLiteral("0") << 11;
+	QTest::addRow("digit_1") << QByteArrayLiteral("1") << 2;
+	QTest::addRow("digit_2") << QByteArrayLiteral("2") << 3;
+	QTest::addRow("digit_3") << QByteArrayLiteral("3") << 4;
+	QTest::addRow("digit_4") << QByteArrayLiteral("4") << 5;
+	QTest::addRow("digit_5") << QByteArrayLiteral("5") << 6;
+	QTest::addRow("digit_6") << QByteArrayLiteral("6") << 7;
+	QTest::addRow("digit_7") << QByteArrayLiteral("7") << 8;
+	QTest::addRow("digit_8") << QByteArrayLiteral("8") << 9;
+	QTest::addRow("digit_9") << QByteArrayLiteral("9") << 10;
+
+	// Shifted digits
+	QTest::addRow("exclam") << QByteArrayLiteral("!") << 2;
+	QTest::addRow("at") << QByteArrayLiteral("@") << 3;
+	QTest::addRow("numbersign") << QByteArrayLiteral("#") << 4;
+	QTest::addRow("dollar") << QByteArrayLiteral("$") << 5;
+	QTest::addRow("percent") << QByteArrayLiteral("%") << 6;
+	QTest::addRow("asciicircum") << QByteArrayLiteral("^") << 7;
+	QTest::addRow("ampersand") << QByteArrayLiteral("&") << 8;
+	QTest::addRow("asterisk") << QByteArrayLiteral("*") << 9;
+	QTest::addRow("parenleft") << QByteArrayLiteral("(") << 10;
+	QTest::addRow("parenright") << QByteArrayLiteral(")") << 11;
+
+	// Minus/underscore and equal/plus
+	QTest::addRow("minus") << QByteArrayLiteral("-") << 12;
+	QTest::addRow("underscore") << QByteArrayLiteral("_") << 12;
+	QTest::addRow("equal") << QByteArrayLiteral("=") << 13;
+	QTest::addRow("plus") << QByteArrayLiteral("+") << 13;
+
+	// Brackets
+	QTest::addRow("bracketleft") << QByteArrayLiteral("[") << 26;
+	QTest::addRow("braceleft") << QByteArrayLiteral("{") << 26;
+	QTest::addRow("bracketright") << QByteArrayLiteral("]") << 27;
+	QTest::addRow("braceright") << QByteArrayLiteral("}") << 27;
+
+	// Semicolon/colon and apostrophe/quote
+	QTest::addRow("semicolon") << QByteArrayLiteral(";") << 39;
+	QTest::addRow("colon") << QByteArrayLiteral(":") << 39;
+	QTest::addRow("apostrophe") << QByteArrayLiteral("'") << 40;
+	QTest::addRow("quotedbl") << QByteArrayLiteral("\"") << 40;
+
+	// Grave/tilde and backslash/bar
+	QTest::addRow("grave") << QByteArrayLiteral("`") << 41;
+	QTest::addRow("asciitilde") << QByteArrayLiteral("~") << 41;
+	QTest::addRow("backslash") << QByteArrayLiteral("\\") << 43;
+	QTest::addRow("bar") << QByteArrayLiteral("|") << 43;
+
+	// Comma/less, period/greater, slash/question
+	QTest::addRow("comma") << QByteArrayLiteral(",") << 51;
+	QTest::addRow("less") << QByteArrayLiteral("<") << 51;
+	QTest::addRow("period") << QByteArrayLiteral(".") << 52;
+	QTest::addRow("greater") << QByteArrayLiteral(">") << 52;
+	QTest::addRow("slash") << QByteArrayLiteral("/") << 53;
+	QTest::addRow("question") << QByteArrayLiteral("?") << 53;
+
+	// Whitespace
+	QTest::addRow("space") << QByteArrayLiteral(" ") << 57;
+	QTest::addRow("newline") << QByteArrayLiteral("\n") << 28;
+	QTest::addRow("tab") << QByteArrayLiteral("\t") << 15;
+}
+
+void LinuxKeyboardMappingTest::testUtf8ToLinuxKeycode()
+{
+	QFETCH(QByteArray, utf8);
+	QFETCH(int, expectedKeycode);
+
+	QCOMPARE(LinuxKeyboardInput::utf8ToLinuxKeycode(utf8), expectedKeycode);
+}
+
+void LinuxKeyboardMappingTest::testUnmappedKeysymReturnsMinusOne()
+{
+	QCOMPARE(LinuxKeyboardInput::keysymToLinuxKeycode(0xdeadbeef), -1);
+}
+
+void LinuxKeyboardMappingTest::testUnmappedUtf8ReturnsMinusOne()
+{
+	QCOMPARE(LinuxKeyboardInput::utf8ToLinuxKeycode(QByteArrayLiteral("\xc3\xa9")), -1);
+}
+
+QTEST_MAIN(LinuxKeyboardMappingTest)
+
+#include "LinuxKeyboardMappingTest.moc"

--- a/tests/unit/PipeWireVncServerTest.cpp
+++ b/tests/unit/PipeWireVncServerTest.cpp
@@ -1,0 +1,212 @@
+// GPLv2 copyright header (2019-2026 Tobias Junghans)
+#include <QObject>
+#include <QTest>
+#include <QString>
+#include <cstdint>
+
+class PipeWireVncServerTest : public QObject
+{
+    Q_OBJECT
+private Q_SLOTS:
+    void testBgrxToRgbConversion();
+    void testDamageRectClamping();
+    void testPortalTokenPattern();
+    void testPortalRequestPath();
+};
+
+static void convertLineBGRxToRgb(const uint8_t* src, int width, uint8_t* dst)
+{
+    for (int x = 0; x < width; ++x) {
+        const int i = x * 4;
+        dst[i + 0] = src[i + 2]; // R = B
+        dst[i + 1] = src[i + 1]; // G = G
+        dst[i + 2] = src[i + 0]; // B = R
+        dst[i + 3] = src[i + 3]; // A = A
+    }
+}
+
+void PipeWireVncServerTest::testBgrxToRgbConversion()
+{
+    // Test single pixel: pure red BGRx (0x00,0x00,0xFF,0xFF) -> RGBA (0xFF,0x00,0x00,0xFF)
+    {
+        uint8_t src[4] = { 0x00, 0x00, 0xFF, 0xFF };
+        uint8_t dst[4] = { 0 };
+        convertLineBGRxToRgb(src, 1, dst);
+        QCOMPARE(dst[0], uint8_t(0xFF));
+        QCOMPARE(dst[1], uint8_t(0x00));
+        QCOMPARE(dst[2], uint8_t(0x00));
+        QCOMPARE(dst[3], uint8_t(0xFF));
+    }
+
+    // Test single pixel: pure green (0x00,0xFF,0x00,0xFF) -> unchanged
+    {
+        uint8_t src[4] = { 0x00, 0xFF, 0x00, 0xFF };
+        uint8_t dst[4] = { 0 };
+        convertLineBGRxToRgb(src, 1, dst);
+        QCOMPARE(dst[0], uint8_t(0x00));
+        QCOMPARE(dst[1], uint8_t(0xFF));
+        QCOMPARE(dst[2], uint8_t(0x00));
+        QCOMPARE(dst[3], uint8_t(0xFF));
+    }
+
+    // Test single pixel: pure blue (0xFF,0x00,0x00,0xFF) -> (0x00,0x00,0xFF,0xFF)
+    {
+        uint8_t src[4] = { 0xFF, 0x00, 0x00, 0xFF };
+        uint8_t dst[4] = { 0 };
+        convertLineBGRxToRgb(src, 1, dst);
+        QCOMPARE(dst[0], uint8_t(0x00));
+        QCOMPARE(dst[1], uint8_t(0x00));
+        QCOMPARE(dst[2], uint8_t(0xFF));
+        QCOMPARE(dst[3], uint8_t(0xFF));
+    }
+
+    // Test multiple pixels with known pattern
+    {
+        // 3 pixels: red, green, blue in BGRx
+        uint8_t src[12] = {
+            0x00, 0x00, 0xFF, 0xFF,  // red in BGRx
+            0x00, 0xFF, 0x00, 0xFF,  // green in BGRx
+            0xFF, 0x00, 0x00, 0xFF   // blue in BGRx
+        };
+        uint8_t dst[12] = { 0 };
+        convertLineBGRxToRgb(src, 3, dst);
+
+        // Pixel 0: should be RGBA red
+        QCOMPARE(dst[0], uint8_t(0xFF));
+        QCOMPARE(dst[1], uint8_t(0x00));
+        QCOMPARE(dst[2], uint8_t(0x00));
+        QCOMPARE(dst[3], uint8_t(0xFF));
+
+        // Pixel 1: should be RGBA green (unchanged)
+        QCOMPARE(dst[4], uint8_t(0x00));
+        QCOMPARE(dst[5], uint8_t(0xFF));
+        QCOMPARE(dst[6], uint8_t(0x00));
+        QCOMPARE(dst[7], uint8_t(0xFF));
+
+        // Pixel 2: should be RGBA blue
+        QCOMPARE(dst[8], uint8_t(0x00));
+        QCOMPARE(dst[9], uint8_t(0x00));
+        QCOMPARE(dst[10], uint8_t(0xFF));
+        QCOMPARE(dst[11], uint8_t(0xFF));
+    }
+
+    // Verify each pixel's 4 bytes are correctly transformed: mixed pattern
+    {
+        // 2 pixels with arbitrary values
+        uint8_t src[8] = {
+            0x10, 0x20, 0x30, 0x40,  // pixel 0
+            0x50, 0x60, 0x70, 0x80   // pixel 1
+        };
+        uint8_t dst[8] = { 0 };
+        convertLineBGRxToRgb(src, 2, dst);
+
+        // Pixel 0: src[B]=0x30 -> dst[R]=0x30, src[G]=0x20 -> dst[G]=0x20, src[R]=0x10 -> dst[B]=0x10, src[A]=0x40 -> dst[A]=0x40
+        QCOMPARE(dst[0], uint8_t(0x30));
+        QCOMPARE(dst[1], uint8_t(0x20));
+        QCOMPARE(dst[2], uint8_t(0x10));
+        QCOMPARE(dst[3], uint8_t(0x40));
+
+        // Pixel 1: src[B]=0x70 -> dst[R]=0x70, src[G]=0x60 -> dst[G]=0x60, src[R]=0x50 -> dst[B]=0x50, src[A]=0x80 -> dst[A]=0x80
+        QCOMPARE(dst[4], uint8_t(0x70));
+        QCOMPARE(dst[5], uint8_t(0x60));
+        QCOMPARE(dst[6], uint8_t(0x50));
+        QCOMPARE(dst[7], uint8_t(0x80));
+    }
+}
+
+void PipeWireVncServerTest::testDamageRectClamping()
+{
+    const int width = 1920;
+    const int height = 1080;
+
+    // Region fully inside: (10,10,100,100) -> clamped to (10,10,110,110)
+    {
+        int x = 10, y = 10, w = 100, h = 100;
+        const int x1 = qBound(0, x, width);
+        const int y1 = qBound(0, y, height);
+        const int x2 = qBound(0, x1 + w, width);
+        const int y2 = qBound(0, y1 + h, height);
+        QCOMPARE(x1, 10);
+        QCOMPARE(y1, 10);
+        QCOMPARE(x2, 110);
+        QCOMPARE(y2, 110);
+    }
+
+    // Region partially outside right edge: (1900,10,100,100) -> x2 clamped to 1920
+    {
+        int x = 1900, y = 10, w = 100, h = 100;
+        const int x1 = qBound(0, x, width);
+        const int y1 = qBound(0, y, height);
+        const int x2 = qBound(0, x1 + w, width);
+        const int y2 = qBound(0, y1 + h, height);
+        QCOMPARE(x1, 1900);
+        QCOMPARE(y1, 10);
+        QCOMPARE(x2, 1920);
+        QCOMPARE(y2, 110);
+    }
+
+    // Region completely outside: (2000,2000,100,100) -> x1=y1=1920,1080 -> x2=y2=1920,1080 -> invalid (not x2>x1)
+    {
+        int x = 2000, y = 2000, w = 100, h = 100;
+        const int x1 = qBound(0, x, width);
+        const int y1 = qBound(0, y, height);
+        const int x2 = qBound(0, x1 + w, width);
+        const int y2 = qBound(0, y1 + h, height);
+        QCOMPARE(x1, 1920);
+        QCOMPARE(y1, 1080);
+        QCOMPARE(x2, 1920);
+        QCOMPARE(y2, 1080);
+        QVERIFY(x2 <= x1);
+        QVERIFY(y2 <= y1);
+    }
+
+    // Negative position: (-10,-10,100,100) -> x1=y1=0 -> x2=100,y2=100
+    {
+        int x = -10, y = -10, w = 100, h = 100;
+        const int x1 = qBound(0, x, width);
+        const int y1 = qBound(0, y, height);
+        const int x2 = qBound(0, x1 + w, width);
+        const int y2 = qBound(0, y1 + h, height);
+        QCOMPARE(x1, 0);
+        QCOMPARE(y1, 0);
+        QCOMPARE(x2, 100);
+        QCOMPARE(y2, 100);
+    }
+}
+
+void PipeWireVncServerTest::testPortalTokenPattern()
+{
+    // makeRequestToken() should return "veyon_" followed by a numeric part
+    QVERIFY(QString("veyon_%1").arg(12345).startsWith("veyon_"));
+    QVERIFY(QString("veyon_%1").arg(0).startsWith("veyon_"));
+    QVERIFY(QString("veyon_%1").arg(999999).startsWith("veyon_"));
+
+    // Verify the numeric part is present after the prefix
+    QString token = QString("veyon_%1").arg(12345);
+    QCOMPARE(token, QString("veyon_12345"));
+}
+
+void PipeWireVncServerTest::testPortalRequestPath()
+{
+    // Test makeRequestPath format: /org/freedesktop/portal/desktop/request/%1/%2
+    const QString senderToken = "sender123";
+    const QString requestToken = "req456";
+    QString path = QString("/org/freedesktop/portal/desktop/request/%1/%2")
+                       .arg(senderToken, requestToken);
+    QCOMPARE(path, QString("/org/freedesktop/portal/desktop/request/sender123/req456"));
+    QVERIFY(path.startsWith("/org/freedesktop/portal/desktop/request/"));
+    QVERIFY(path.endsWith("/req456"));
+
+    // Test with empty tokens
+    QString pathEmpty = QString("/org/freedesktop/portal/desktop/request/%1/%2")
+                            .arg(QString(), QString());
+    QCOMPARE(pathEmpty, QString("/org/freedesktop/portal/desktop/request//"));
+
+    // Test with special characters in tokens
+    QString pathSpecial = QString("/org/freedesktop/portal/desktop/request/%1/%2")
+                              .arg(QString("test_user"), QString("req_42"));
+    QCOMPARE(pathSpecial, QString("/org/freedesktop/portal/desktop/request/test_user/req_42"));
+}
+
+QTEST_MAIN(PipeWireVncServerTest)
+#include "PipeWireVncServerTest.moc"


### PR DESCRIPTION
- Read /proc/<leader>/environ of the session leader directly (getSessionEnvironment) and fix process-tree traversal to not abort on null environ
- Inject DBUS_SESSION_BUS_ADDRESS, XDG_RUNTIME_DIR, WAYLAND_DISPLAY from well-known paths (/run/user/<UID>/) as fallback for Wayland
- Launch veyon-server directly via QProcess instead of through kioclient/gio D-Bus activation which strips the injected env
- Call initgroups()+setgid()+setuid() in setProcessUserId() so the server process has full user credentials (UID, GID, groups); Portal/RemoteDesktop requires this to grant screen access

Now service works fine with systemctl start and start with button in configurator.