### PR TITLE
File Transfer: runtime path selection

### DIFF
--- a/plugins/filetransfer/FileCollectController.cpp
+++ b/plugins/filetransfer/FileCollectController.cpp
@@ -36,7 +36,10 @@ FileCollectController::FileCollectController(FileTransferPlugin* plugin) :
 	m_collectedFilesGroupingMode(configuration().collectedFilesGroupingMode()),
 	m_collectedFilesGroupingAttributes({configuration().collectedFilesGroupingAttribute1(),
 									   configuration().collectedFilesGroupingAttribute2(),
-									   configuration().collectedFilesGroupingAttribute3()})
+									   configuration().collectedFilesGroupingAttribute3()}),
+	m_collectSourceDirectory(),
+	m_filePattern(),
+	m_collectRecursively(configuration().collectFilesRecursively())
 {
 	connect (this, &FileCollectController::collectionChanged, this, &FileCollectController::overallProgressChanged);
 }
@@ -52,6 +55,34 @@ FileCollectController::~FileCollectController()
 const FileTransferConfiguration& FileCollectController::configuration() const
 {
 	return m_plugin->configuration();
+}
+
+
+
+void FileCollectController::setCollectSourceDirectory(const QString& sourceDir)
+{
+	m_collectSourceDirectory = sourceDir;
+}
+
+
+
+void FileCollectController::setFilePattern(const QString& pattern)
+{
+	m_filePattern = pattern;
+}
+
+
+
+void FileCollectController::setCollectRecursively(bool recursive)
+{
+	m_collectRecursively = recursive;
+}
+
+
+
+void FileCollectController::setDestinationDirectory(const QString& destDir)
+{
+	m_destinationDirectory = destDir;
 }
 
 
@@ -176,7 +207,8 @@ void FileCollectController::start()
 	{
 		for (auto it = m_collections.constBegin(), end = m_collections.constEnd(); it != end; ++it)
 		{
-			m_plugin->sendInitFileCollectionMessage(it.value(), it.key());
+			m_plugin->sendInitFileCollectionMessage(it.value(), it.key(),
+													m_collectSourceDirectory, m_filePattern, m_collectRecursively);
 		}
 
 		m_running = true;

--- a/plugins/filetransfer/FileCollectController.h
+++ b/plugins/filetransfer/FileCollectController.h
@@ -79,6 +79,15 @@ public:
 	void setInterfaces(const ComputerControlInterfaceList& computerControlInterfaces);
 	void setCollectionName(const QString& collectionName);
 
+	void setCollectSourceDirectory(const QString& sourceDir);
+	void setFilePattern(const QString& pattern);
+	void setCollectRecursively(bool recursive);
+	void setDestinationDirectory(const QString& destDir);
+
+	QString collectSourceDirectory() const { return m_collectSourceDirectory; }
+	QString filePattern() const { return m_filePattern; }
+	bool collectRecursively() const { return m_collectRecursively; }
+
 	QString outputDirectory() const;
 
 	QString outputFilePath(ComputerControlInterface::Pointer computerControlInterface,
@@ -140,6 +149,10 @@ private:
 	CollectionDirectory m_collectionDirectory;
 	CollectedFilesGroupingMode m_collectedFilesGroupingMode;
 	std::array<CollectedFilesGroupingAttribute, 3> m_collectedFilesGroupingAttributes;
+
+	QString m_collectSourceDirectory;
+	QString m_filePattern;
+	bool m_collectRecursively = false;
 
 	bool m_running = false;
 

--- a/plugins/filetransfer/FileCollectDialog.cpp
+++ b/plugins/filetransfer/FileCollectDialog.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <QDesktopServices>
+#include <QFileDialog>
 #include <QInputDialog>
 #include <QPushButton>
 #include <QScreen>
@@ -30,6 +31,7 @@
 #include "FileCollectController.h"
 #include "FileCollectDialog.h"
 #include "FileCollectTreeModel.h"
+#include "FileSystemBrowser.h"
 #include "Filesystem.h"
 #include "ProgressItemDelegate.h"
 
@@ -47,6 +49,25 @@ FileCollectDialog::FileCollectDialog(FileCollectController* controller, QWidget*
 	ui->collectionsTreeView->setItemDelegateForColumn(int(FileCollectTreeModel::Column::Progress),
 													  new ProgressItemDelegate(ui->collectionsTreeView));
 	ui->collectionsTreeView->setModel(m_model);
+
+	// Initialize source directory from controller / default config
+	ui->sourceDirectoryEdit->setText(m_controller->collectSourceDirectory());
+
+	// Initialize file pattern
+	ui->filePatternEdit->setText(m_controller->filePattern());
+
+	// Initialize output directory
+	ui->outputDirectoryEdit->setText(m_controller->outputDirectory());
+
+	connect (ui->browseOutputDirectoryButton, &QAbstractButton::clicked, this, [this]() {
+		const auto dir = QFileDialog::getExistingDirectory(this, tr("Select output directory"),
+														   ui->outputDirectoryEdit->text());
+		if (dir.isEmpty() == false)
+		{
+			ui->outputDirectoryEdit->setText(dir);
+			m_controller->setDestinationDirectory(dir);
+		}
+	});
 
 	connect (ui->openOutputDirectoryButton, &QAbstractButton::clicked, this, &FileCollectDialog::openOutputDirectory);
 
@@ -104,6 +125,19 @@ void FileCollectDialog::accept()
 		break;
 	}
 
+	// Pass source directory and file pattern to controller
+	const auto sourceDir = ui->sourceDirectoryEdit->text().trimmed();
+	if (sourceDir.isEmpty() == false)
+	{
+		m_controller->setCollectSourceDirectory(sourceDir);
+	}
+
+	const auto filePattern = ui->filePatternEdit->text().trimmed();
+	if (filePattern.isEmpty() == false)
+	{
+		m_controller->setFilePattern(filePattern);
+	}
+
 	if (VeyonCore::filesystem().ensurePathExists(m_controller->outputDirectory()) == false)
 	{
 		QMessageBox::critical(this, tr("Output directory creation failed"),
@@ -114,6 +148,11 @@ void FileCollectDialog::accept()
 
 	ui->outputDirectoryEdit->setText(m_controller->outputDirectory());
 	ui->openOutputDirectoryButton->setEnabled(true);
+
+	// Disable source/pattern and output dir editing during transfer
+	ui->sourceGroupBox->setEnabled(false);
+	ui->outputDirectoryEdit->setEnabled(false);
+	ui->browseOutputDirectoryButton->setEnabled(false);
 
 	m_controller->start();
 }

--- a/plugins/filetransfer/FileCollectDialog.ui
+++ b/plugins/filetransfer/FileCollectDialog.ui
@@ -11,6 +11,43 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
+    <widget class="QGroupBox" name="sourceGroupBox">
+     <property name="title">
+      <string>Source (on student computers)</string>
+     </property>
+     <layout class="QGridLayout" name="sourceLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="sourceDirLabel">
+        <property name="text">
+         <string>Source directory:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="sourceDirectoryEdit">
+        <property name="placeholderText">
+         <string>Relative (Documents/) or absolute (/tmp/ or C:\TMP) or empty for configured directory</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="filePatternLabel">
+        <property name="text">
+         <string>File pattern:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="filePatternEdit">
+        <property name="placeholderText">
+         <string>*.* or *.docx;*.pdf (leave empty for all files)</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Collected files</string>
@@ -45,16 +82,24 @@
    <item>
     <widget class="QGroupBox" name="outputDirectoryGroupBox">
      <property name="title">
-      <string>Output directory</string>
+      <string>Output directory (local)</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
        <widget class="QLineEdit" name="outputDirectoryEdit">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
         <property name="readOnly">
          <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="browseOutputDirectoryButton">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="icon">
+         <iconset resource="../../core/resources/core.qrc">
+          <normaloff>:/core/document-edit.png</normaloff>:/core/document-edit.png</iconset>
         </property>
        </widget>
       </item>

--- a/plugins/filetransfer/FileCollectWorker.cpp
+++ b/plugins/filetransfer/FileCollectWorker.cpp
@@ -80,10 +80,21 @@ static QStringList listFilesInDirectory(const QString& dirPath, const QList<QReg
 
 
 
-FileCollectWorker::FileCollectWorker(FileTransferPlugin* plugin) :
+FileCollectWorker::FileCollectWorker(FileTransferPlugin* plugin,
+									 const QString& sourceDirectory,
+									 const QString& filePattern,
+									 bool collectRecursively) :
 	QObject(plugin),
 	m_configuration(plugin->configuration()),
-	m_sourceDirectory(VeyonCore::filesystem().expandPath(m_configuration.filesToCollectSourceDirectory()))
+	m_sourceDirectory(sourceDirectory.isEmpty() ?
+						  VeyonCore::filesystem().expandPath(m_configuration.filesToCollectSourceDirectory())
+						:
+						  (QDir::isAbsolutePath(sourceDirectory) ?
+						   sourceDirectory
+						 :
+						   QDir::toNativeSeparators(QDir::homePath() + QLatin1Char('/') + sourceDirectory))),
+	m_filePattern(filePattern),
+	m_collectRecursively(collectRecursively || m_configuration.collectFilesRecursively())
 {
 	if (m_sourceDirectory.endsWith(QDir::separator()) == false)
 	{
@@ -156,7 +167,9 @@ bool FileCollectWorker::currentFileAtEnd() const
 
 void FileCollectWorker::initFiles()
 {
-	m_files = listFilesInDirectory(m_sourceDirectory, excludeRegExes(), m_configuration.collectFilesRecursively());
+	m_files = listFilesInDirectory(m_sourceDirectory, excludeRegExes(), m_collectRecursively);
+
+	m_files = filterFilesByPattern(m_files, m_filePattern);
 
 	for (auto it = m_files.begin(); it != m_files.end(); ) // clazy:exclude=detaching-member
 	{
@@ -199,4 +212,53 @@ QList<QRegularExpression> FileCollectWorker::excludeRegExes() const
 	});
 
 	return regExes;
+}
+
+
+
+QStringList FileCollectWorker::filterFilesByPattern(const QStringList& files, const QString& pattern) const
+{
+	if (pattern.isEmpty())
+	{
+		return files;
+	}
+
+	auto patternStr = pattern;
+	const auto globPatterns = patternStr.replace(u';', u' ')
+								       .replace(u',', u' ').split(u' ', Qt::SkipEmptyParts);
+	if (globPatterns.isEmpty())
+	{
+		return files;
+	}
+
+	QList<QRegularExpression> regExes;
+	std::transform(globPatterns.begin(), globPatterns.end(),
+				   std::back_inserter(regExes),
+				   [](const QString& glob) {
+		return QRegularExpression(QString(glob).replace(u'*', QStringLiteral(".*")),
+								  QRegularExpression::CaseInsensitiveOption);
+	});
+
+	QStringList filtered;
+	filtered.reserve(files.size());
+
+	for (const auto& file : files)
+	{
+		const auto fileName = QFileInfo(file).fileName();
+		bool matched = false;
+		for (const auto& re : regExes)
+		{
+			if (re.match(fileName).hasMatch())
+			{
+				matched = true;
+				break;
+			}
+		}
+		if (matched)
+		{
+			filtered.append(file);
+		}
+	}
+
+	return filtered;
 }

--- a/plugins/filetransfer/FileCollectWorker.h
+++ b/plugins/filetransfer/FileCollectWorker.h
@@ -42,7 +42,10 @@ public:
 		AllFinished
 	};
 
-	explicit FileCollectWorker(FileTransferPlugin* plugin);
+	explicit FileCollectWorker(FileTransferPlugin* plugin,
+							   const QString& sourceDirectory = {},
+							   const QString& filePattern = {},
+							   bool collectRecursively = false);
 	~FileCollectWorker() override;
 
 	FileCollection::TransferId currentTransferId() const
@@ -75,11 +78,14 @@ public:
 private:
 	void initFiles();
 	QList<QRegularExpression> excludeRegExes() const;
+	QStringList filterFilesByPattern(const QStringList& files, const QString& pattern) const;
 
 	static constexpr int ChunkSize = 256*1024;
 
 	const FileTransferConfiguration& m_configuration;
 	QString m_sourceDirectory;
+	QString m_filePattern;
+	bool m_collectRecursively;
 
 	QStringList m_files;
 	int m_currentFileIndex = -1;

--- a/plugins/filetransfer/FileTransferController.cpp
+++ b/plugins/filetransfer/FileTransferController.cpp
@@ -39,7 +39,8 @@ FileTransferController::FileTransferController( FileTransferPlugin* plugin ) :
 	m_interfaces(),
 	m_fileReadThread( nullptr ),
 	m_fileState( FileStateFinished ),
-	m_processTimer( this )
+	m_processTimer( this ),
+	m_destinationDirectory()
 {
 	m_processTimer.setInterval( ProcessInterval );
 	connect( &m_processTimer, &QTimer::timeout, this, &FileTransferController::process );
@@ -76,6 +77,13 @@ void FileTransferController::setInterfaces( const ComputerControlInterfaceList& 
 void FileTransferController::setFlags( Flags flags )
 {
 	m_flags = flags;
+}
+
+
+
+void FileTransferController::setDestinationDirectory( const QString& destDir )
+{
+	m_destinationDirectory = destDir;
 }
 
 
@@ -207,7 +215,8 @@ bool FileTransferController::openFile()
 	m_currentTransferId = QUuid::createUuid();
 
 	m_plugin->sendStartMessage( m_currentTransferId, QFileInfo(m_files.value(m_currentFileIndex)).fileName(),
-								m_flags.testFlag( OverwriteExistingFiles ), m_interfaces );
+								m_flags.testFlag( OverwriteExistingFiles ), m_interfaces,
+								m_destinationDirectory );
 
 	return true;
 }

--- a/plugins/filetransfer/FileTransferController.h
+++ b/plugins/filetransfer/FileTransferController.h
@@ -51,6 +51,7 @@ public:
 	void setFiles( const QStringList& files );
 	void setInterfaces( const ComputerControlInterfaceList& interfaces );
 	void setFlags( Flags flags );
+	void setDestinationDirectory( const QString& destDir );
 
 	void start();
 	void stop();
@@ -101,5 +102,7 @@ private:
 	FileState m_fileState;
 
 	QTimer m_processTimer;
+
+	QString m_destinationDirectory;
 
 };

--- a/plugins/filetransfer/FileTransferDialog.cpp
+++ b/plugins/filetransfer/FileTransferDialog.cpp
@@ -27,6 +27,7 @@
 #include "FileTransferController.h"
 #include "FileTransferDialog.h"
 #include "FileTransferListModel.h"
+#include "Filesystem.h"
 
 #include "ui_FileTransferDialog.h"
 
@@ -61,6 +62,7 @@ FileTransferDialog::~FileTransferDialog()
 
 void FileTransferDialog::accept()
 {
+	ui->destinationGroupBox->setDisabled( true );
 	ui->optionsGroupBox->setDisabled( true );
 	ui->buttonBox->setStandardButtons( QDialogButtonBox::Cancel );
 
@@ -79,6 +81,13 @@ void FileTransferDialog::accept()
 	if( ui->overwriteExistingFiles->isChecked() )
 	{
 		flags |= FileTransferController::OverwriteExistingFiles;
+	}
+
+	// Set custom destination directory if provided
+	const auto destDir = ui->destinationDirectoryEdit->text().trimmed();
+	if( destDir.isEmpty() == false )
+	{
+		m_controller->setDestinationDirectory( destDir );
 	}
 
 	m_controller->setFlags( flags );

--- a/plugins/filetransfer/FileTransferDialog.ui
+++ b/plugins/filetransfer/FileTransferDialog.ui
@@ -12,6 +12,22 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
+    <widget class="QGroupBox" name="destinationGroupBox">
+     <property name="title">
+      <string>Destination (on student computers)</string>
+     </property>
+     <layout class="QVBoxLayout" name="destinationLayout">
+      <item>
+       <widget class="QLineEdit" name="destinationDirectoryEdit">
+        <property name="placeholderText">
+         <string>Relative (Desktop/) or absolute (/tmp/ or C:\TMP) or empty for configured directory</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="optionsGroupBox">
      <property name="title">
       <string>Options</string>
@@ -89,6 +105,7 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>destinationDirectoryEdit</tabstop>
   <tabstop>overwriteExistingFiles</tabstop>
   <tabstop>transferOnly</tabstop>
   <tabstop>transferAndOpenProgram</tabstop>

--- a/plugins/filetransfer/FileTransferPlugin.cpp
+++ b/plugins/filetransfer/FileTransferPlugin.cpp
@@ -46,6 +46,20 @@
 #include "VeyonWorkerInterface.h"
 
 
+// Resolve a path relative to the active user's home directory.
+// Absolute paths (starting with /) are returned as-is.
+// Relative paths are prefixed with the user's home directory.
+// Empty paths are returned as-is.
+static QString resolvePathToHome(const QString& path)
+{
+	if (path.isEmpty())
+		return path;
+	if (QDir::isAbsolutePath(path))
+		return path;
+	return QDir::toNativeSeparators(QDir::homePath() + QLatin1Char('/') + path);
+}
+
+
 FileTransferPlugin::FileTransferPlugin( QObject* parent ) :
 	QObject( parent ),
 	m_distributeFilesFeature(QStringLiteral("DistributeFiles"),
@@ -283,13 +297,20 @@ bool FileTransferPlugin::handleFeatureMessage( VeyonWorkerInterface& worker, con
 
 
 void FileTransferPlugin::sendStartMessage( QUuid transferId, const QString& fileName,
-										   bool overwriteExistingFile, const ComputerControlInterfaceList& interfaces )
+										   bool overwriteExistingFile, const ComputerControlInterfaceList& interfaces,
+										   const QString& destinationDirectory )
 {
-	sendFeatureMessage(FeatureMessage(m_distributeFilesFeature.uid(), FeatureCommand::StartFileTransfer).
-					   addArgument(Argument::TransferId, transferId).
-					   addArgument(Argument::FileName, fileName).
-					   addArgument(Argument::OverwriteExistingFile, overwriteExistingFile),
-					   interfaces);
+	FeatureMessage msg(m_distributeFilesFeature.uid(), FeatureCommand::StartFileTransfer);
+	msg.addArgument(Argument::TransferId, transferId);
+	msg.addArgument(Argument::FileName, fileName);
+	msg.addArgument(Argument::OverwriteExistingFile, overwriteExistingFile);
+
+	if (destinationDirectory.isEmpty() == false)
+	{
+		msg.addArgument(Argument::DestinationDirectory, destinationDirectory);
+	}
+
+	sendFeatureMessage(msg, interfaces);
 }
 
 
@@ -339,7 +360,8 @@ void FileTransferPlugin::sendStopWorkerMessage(const ComputerControlInterfaceLis
 
 
 
-void FileTransferPlugin::sendInitFileCollectionMessage(const FileCollection& collection, ComputerControlInterface::Pointer computerControlInterface)
+void FileTransferPlugin::sendInitFileCollectionMessage(const FileCollection& collection,
+													   ComputerControlInterface::Pointer computerControlInterface)
 {
 	computerControlInterface->sendFeatureMessage(
 				FeatureMessage(m_collectFilesFeature.uid(), FeatureCommand::InitFileCollection)
@@ -347,8 +369,32 @@ void FileTransferPlugin::sendInitFileCollectionMessage(const FileCollection& col
 }
 
 
+void FileTransferPlugin::sendInitFileCollectionMessage(const FileCollection& collection,
+													   ComputerControlInterface::Pointer computerControlInterface,
+													   const QString& sourceDirectory,
+													   const QString& filePattern,
+													   bool collectRecursively)
+{
+	FeatureMessage msg(m_collectFilesFeature.uid(), FeatureCommand::InitFileCollection);
+	msg.addArgument(Argument::CollectionId, collection.id);
 
-void FileTransferPlugin::sendFinishFileCollectionMessage(const FileCollection& collection, ComputerControlInterface::Pointer computerControlInterface)
+	if (sourceDirectory.isEmpty() == false)
+	{
+		msg.addArgument(Argument::SourceDirectory, sourceDirectory);
+	}
+	if (filePattern.isEmpty() == false)
+	{
+		msg.addArgument(Argument::FilePattern, filePattern);
+	}
+	msg.addArgument(Argument::CollectRecursively, collectRecursively);
+
+	computerControlInterface->sendFeatureMessage(msg);
+}
+
+
+
+void FileTransferPlugin::sendFinishFileCollectionMessage(const FileCollection& collection,
+														 ComputerControlInterface::Pointer computerControlInterface)
 {
 	computerControlInterface->sendFeatureMessage(
 				FeatureMessage(m_collectFilesFeature.uid(), FeatureCommand::FinishFileCollection)
@@ -357,7 +403,8 @@ void FileTransferPlugin::sendFinishFileCollectionMessage(const FileCollection& c
 
 
 
-void FileTransferPlugin::sendStartFileTransferMessage(const FileCollection& collection, ComputerControlInterface::Pointer computerControlInterface)
+void FileTransferPlugin::sendStartFileTransferMessage(const FileCollection& collection,
+													  ComputerControlInterface::Pointer computerControlInterface)
 {
 	computerControlInterface->sendFeatureMessage(
 				FeatureMessage(m_collectFilesFeature.uid(), FeatureCommand::StartFileTransfer)
@@ -366,7 +413,8 @@ void FileTransferPlugin::sendStartFileTransferMessage(const FileCollection& coll
 
 
 
-void FileTransferPlugin::sendContinueFileTransferMessage(const FileCollection& collection, ComputerControlInterface::Pointer computerControlInterface)
+void FileTransferPlugin::sendContinueFileTransferMessage(const FileCollection& collection,
+														 ComputerControlInterface::Pointer computerControlInterface)
 {
 	computerControlInterface->sendFeatureMessage(
 				FeatureMessage(m_collectFilesFeature.uid(), FeatureCommand::ContinueFileTransfer)
@@ -447,7 +495,25 @@ bool FileTransferPlugin::handleDistributeFilesMessage(const FeatureMessage& mess
 	case FeatureCommand::StartFileTransfer:
 		m_currentFile.close();
 
-		m_currentFileName = destinationDirectory() + QDir::separator() + message.argument(Argument::FileName).toString();
+		{
+			// Use custom destination directory if provided, otherwise fall back to config
+			QString destDir;
+			if (message.hasArgument(Argument::DestinationDirectory))
+			{
+				destDir = resolvePathToHome(
+								  message.argument(Argument::DestinationDirectory).toString());
+			}
+			if (destDir.isEmpty())
+			{
+				destDir = destinationDirectory();
+			}
+			if (QDir(destDir).exists() == false)
+			{
+				VeyonCore::filesystem().ensurePathExists(destDir);
+			}
+
+			m_currentFileName = destDir + QDir::separator() + message.argument(Argument::FileName).toString();
+		}
 		m_currentFile.setFileName(m_currentFileName);
 		if( m_currentFile.exists() && message.argument(Argument::OverwriteExistingFile).toBool() == false )
 		{
@@ -539,7 +605,10 @@ bool FileTransferPlugin::handleCollectFilesMessage(VeyonWorkerInterface& worker,
 	case FeatureCommand::InitFileCollection:
 		if (fileCollectWorker == nullptr)
 		{
-			fileCollectWorker = new FileCollectWorker(this);
+			const auto sourceDir = message.argument(Argument::SourceDirectory).toString();
+			const auto filePattern = message.argument(Argument::FilePattern).toString();
+			const auto collectRecursively = message.argument(Argument::CollectRecursively).toBool();
+			fileCollectWorker = new FileCollectWorker(this, sourceDir, filePattern, collectRecursively);
 			m_fileCollectWorkers[collectionId] = fileCollectWorker;
 		}
 		worker.sendFeatureMessageReply(reply.addArgument(Argument::Files, fileCollectWorker->files()));
@@ -654,6 +723,13 @@ bool FileTransferPlugin::controlDistributeFilesFeature(Operation operation, cons
 
 		m_fileTransferController->setFiles(files);
 		m_fileTransferController->setInterfaces(computerControlInterfaces);
+
+		// Set custom destination directory if provided
+		if (arguments.contains(argToString(Argument::DestinationDirectory)))
+		{
+			m_fileTransferController->setDestinationDirectory(
+						arguments.value(argToString(Argument::DestinationDirectory)).toString());
+		}
 
 		return true;
 	}

--- a/plugins/filetransfer/FileTransferPlugin.h
+++ b/plugins/filetransfer/FileTransferPlugin.h
@@ -68,6 +68,10 @@ public:
 		Files,
 		CollectionId,
 		FileSize,
+		SourceDirectory,
+		FilePattern,
+		CollectRecursively,
+		DestinationDirectory,
 	};
 	Q_ENUM(Argument)
 
@@ -132,7 +136,8 @@ public:
 	bool handleFeatureMessage( VeyonWorkerInterface& worker, const FeatureMessage& message ) override;
 
 	void sendStartMessage( QUuid transferId, const QString& fileName,
-						   bool overwriteExistingFile, const ComputerControlInterfaceList& interfaces );
+						   bool overwriteExistingFile, const ComputerControlInterfaceList& interfaces,
+						   const QString& destinationDirectory = {} );
 	void sendDataMessage( QUuid transferId, const QByteArray& data, const ComputerControlInterfaceList& interfaces );
 	void sendCancelMessage( QUuid transferId, const ComputerControlInterfaceList& interfaces );
 	void sendFinishMessage( QUuid transferId, const QString& fileName,
@@ -142,6 +147,11 @@ public:
 
 	void sendInitFileCollectionMessage(const FileCollection& collection,
 									   ComputerControlInterface::Pointer computerControlInterface);
+	void sendInitFileCollectionMessage(const FileCollection& collection,
+									   ComputerControlInterface::Pointer computerControlInterface,
+									   const QString& sourceDirectory,
+									   const QString& filePattern,
+									   bool collectRecursively);
 	void sendFinishFileCollectionMessage(const FileCollection& collection,
 										 ComputerControlInterface::Pointer computerControlInterface);
 


### PR DESCRIPTION
Allow choosing source and destination directories at transfer time.

Collect dialog:
- Add source directory and file pattern fields
- Add output directory browse button for local save path
- Pass chosen values via InitFileCollection message
- Disable source/output fields during transfer

Distribute dialog:
- Add destination directory field
- Pass chosen value via StartFileTransfer message

Add new FeatureMessage arguments: SourceDirectory, FilePattern, CollectRecursively, DestinationDirectory.

Path resolution on the student-side worker:
- Absolute paths are used as-is (QDir::isAbsolutePath)
- Relative paths are prefixed with QDir::homePath()
- Falls back to configured default when path is empty

FileCollectWorker accepts sourceDirectory, filePattern and collectRecursively as constructor parameters.
handleDistributeFilesMessage reads DestinationDirectory argument and creates the directory if needed.