### PR TITLE
fix(core): pass auth token to managed system workers via stdin

### DIFF
--- a/core/src/FeatureWorkerManager.cpp
+++ b/core/src/FeatureWorkerManager.cpp
@@ -105,6 +105,8 @@ bool FeatureWorkerManager::startManagedSystemWorker( Feature::Uid featureUid )
 		worker.process->start( VeyonCore::filesystem().workerFilePath(), { featureUid.toString() } );
 	}
 
+	worker.process->write(worker.token + '\n');
+
 	m_workersMutex.lock();
 	m_workers[featureUid] = worker;
 	m_workersMutex.unlock();


### PR DESCRIPTION
Commit 7d29cc82b added worker authentication with a token mechanism, but only passed the token for unmanaged session workers. Managed system workers (used by DemoServer) never received their token, preventing them from authenticating and receiving feature messages. This caused DemoServer to silently fail to start.

Write the auth token to the QProcess stdin after starting a managed system worker, matching the unmanaged worker path.