### PR TITLE
fix(builtindirectory): fix location table state and button management

### DIFF
--- a/plugins/builtindirectory/BuiltinDirectoryConfigurationPage.cpp
+++ b/plugins/builtindirectory/BuiltinDirectoryConfigurationPage.cpp
@@ -111,11 +111,22 @@ void BuiltinDirectoryConfigurationPage::updateLocation()
 
 void BuiltinDirectoryConfigurationPage::removeLocation()
 {
+	auto currentRow = ui->locationTableWidget->currentRow();
+
 	ObjectManager<NetworkObject> objectManager( m_configuration.networkObjects() );
 	objectManager.remove( currentLocationObject().uid(), true );
 	m_configuration.setNetworkObjects( objectManager.objects() );
 
 	populateLocations();
+
+	if( currentRow > 0 )
+	{
+		ui->locationTableWidget->setCurrentCell( currentRow-1, 0 );
+	}
+	else if ( ui->locationTableWidget->rowCount() > 0 )
+	{
+		ui->locationTableWidget->setCurrentCell( currentRow, 0 );
+	}
 }
 
 
@@ -253,6 +264,9 @@ void BuiltinDirectoryConfigurationPage::populateLocations()
 {
 	ui->locationTableWidget->setUpdatesEnabled( false );
 	ui->locationTableWidget->clear();
+	ui->locationTableWidget->setRowCount( 0 );
+
+	ui->addComputerButton->setEnabled( false );
 
 	int rowCount = 0;
 
@@ -270,6 +284,9 @@ void BuiltinDirectoryConfigurationPage::populateLocations()
 	}
 
 	ui->locationTableWidget->setUpdatesEnabled( true );
+
+	if( rowCount > 0 )
+		ui->addComputerButton->setEnabled( true );
 }
 
 
@@ -304,6 +321,8 @@ void BuiltinDirectoryConfigurationPage::populateComputers()
 	}
 
 	ui->computerTableWidget->setUpdatesEnabled( true );
+
+	ui->addComputerButton->setEnabled( currentLocationObject().uid().isNull() == false );
 }
 
 


### PR DESCRIPTION
- Reset row count to zero after clearing location table to prevent stale rows from persisting on empty repopulation.
- Properly disable addComputerButton when no locations exist, enable only when rowCount > 0.
- Preserve row selection in removeLocation() by selecting the previous row after removal, keeping the first row selected when it was the target.

Adding computers without adding places worked buggy, so computers now being added only with at least 1 place.