### PR TITLE
Fix: Crash in CLI when listing available commands

### DIFF
--- a/cli/src/main.cpp
+++ b/cli/src/main.cpp
@@ -138,8 +138,6 @@ int main( int argc, char **argv )
 				runResult = CommandLinePluginInterface::NotEnoughArguments;
 			}
 
-			delete core;
-			delete app;
 
 			switch( runResult )
 			{


### PR DESCRIPTION
Fixes a small crash in veyon-cli when, after an invalid command, it deleted the `core` and `app` objects and then tried to use them to enumerate all available commands. We just remove the early delete statements.

You can reproduce this bug with `veyon-cli authkeys aaaaa`